### PR TITLE
fs.renameSync() may fail across partition boundaries. Use copy + unlink instead

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -82,10 +82,10 @@ class ModuleCache {
 				const destDir = path.join(releaseDir, p.name);
 				mkdirp.sync(destDir);
 				const destFile = path.join(destDir, path.basename(m.file));
-				if (m.isAsset) {
-					fs.copyFileSync(m.file, destFile);
-				} else {
-					fs.renameSync(m.file, destFile);
+				// NOTE: fs.renameSync() may fail across partitions at least on Linux
+				fs.copyFileSync(m.file, destFile);
+				if (!m.isAsset) {
+					fs.unlinkSync(m.file);
 				}
 				m.file = destFile;
 			}


### PR DESCRIPTION
As title says.

```
$ device-os-flash --all-devices -r 999 -j 1 1.5.4-rc.2
Initializing module cache
Found cached module binaries
Downloading release binaries
Updating cached binaries
Error: EXDEV: cross-device link not permitted, rename '/tmp/device-os-flash-20940TrepkXMt7cvh/downloads/1.5.4-rc.2/argon-bootloader@1.5.4-rc.2.bin' -> '/home/xxx/.particle/device-os-flash/binaries/1.5.4-rc.2/argon/argon-bootloader@1.5.4-rc.2.bin'
```