### PR TITLE
Update particle-usb

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,10 +17,8 @@ jobs:
       matrix:
         node:
           - 12
-          # TODO: The currently used version of node-usb doesn't have prebuilt binaries for
-          # Node.js 14 and higher: https://github.com/particle-iot/particle-usb/pull/47
-          # - 14
-          # - 16
+          - 14
+          - 16
         optional:
           - false
     steps:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -587,6 +587,11 @@
 				"@octokit/openapi-types": "^9.5.0"
 			}
 		},
+		"@particle/device-constants": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-1.3.0.tgz",
+			"integrity": "sha512-OI7K5yEsN8R/ommsM0IiFfQSEN0NhPFelQGLKIQ+yNXUVvEsZOW18QdZirLreKIheIrqsZOhuqppDp0orykL6g=="
+		},
 		"@protobufjs/aspromise": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -710,7 +710,8 @@
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "4.2.1",
@@ -740,11 +741,6 @@
 				"default-require-extensions": "^3.0.0"
 			}
 		},
-		"aproba": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-		},
 		"archive-type": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/archive-type/-/archive-type-4.0.0.tgz",
@@ -765,15 +761,6 @@
 			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
 			"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
 			"dev": true
-		},
-		"are-we-there-yet": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
-			}
 		},
 		"argparse": {
 			"version": "2.0.1",
@@ -850,14 +837,6 @@
 				"h5.buffers": "^0.1.1",
 				"when": "^3.7.3",
 				"xtend": "^4.0.2"
-			}
-		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"requires": {
-				"file-uri-to-path": "1.0.0"
 			}
 		},
 		"bit-mask": {
@@ -1102,11 +1081,6 @@
 				}
 			}
 		},
-		"chownr": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
-		},
 		"clean-stack": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -1169,7 +1143,8 @@
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
 		},
 		"color-convert": {
 			"version": "2.0.1",
@@ -1221,11 +1196,6 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-		},
-		"console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
 		"content-disposition": {
 			"version": "0.5.3",
@@ -1402,11 +1372,6 @@
 				"type-detect": "^4.0.0"
 			}
 		},
-		"deep-extend": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
-		},
 		"deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1427,20 +1392,10 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
-		"delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-		},
 		"deprecation": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
 			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
-		},
-		"detect-libc": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
 		},
 		"diff": {
 			"version": "5.0.0",
@@ -1773,11 +1728,6 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
-		"expand-template": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
-		},
 		"ext-list": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
@@ -1870,11 +1820,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
 			"integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
-		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
 		"filename-reserved-regex": {
 			"version": "2.0.0",
@@ -2056,21 +2001,6 @@
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
 		},
-		"gauge": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"requires": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
-			}
-		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2102,11 +2032,6 @@
 			"requires": {
 				"pump": "^3.0.0"
 			}
-		},
-		"github-from-package": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
 		},
 		"glob": {
 			"version": "7.1.6",
@@ -2216,11 +2141,6 @@
 				"has-symbol-support-x": "^1.4.1"
 			}
 		},
-		"has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-		},
 		"hasha": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
@@ -2311,11 +2231,6 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
-		"ini": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-		},
 		"into-stream": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
@@ -2343,6 +2258,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -2781,11 +2697,6 @@
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
 			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
 		},
-		"mkdirp-classic": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.2.tgz",
-			"integrity": "sha512-ejdnDQcR75gwknmMw/tx02AuRs8jCtqFoFqDZMjiNxsu85sRIJVXDKHuLYvUUPRBUtV2FpSZa9bL1BUa3BdR2g=="
-		},
 		"mocha": {
 			"version": "9.0.3",
 			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.0.3.tgz",
@@ -2884,42 +2795,17 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
-		"nan": {
-			"version": "2.13.2",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-			"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
-		},
 		"nanoid": {
 			"version": "3.1.23",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
 			"integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
 			"dev": true
 		},
-		"napi-build-utils": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
-		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
-		},
-		"node-abi": {
-			"version": "2.15.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.15.0.tgz",
-			"integrity": "sha512-FeLpTS0F39U7hHZU1srAK4Vx+5AHNVOTP+hxBNQknR/54laTHSFIJkDWDqiquY1LeLUgTfPN7sLPhMubx0PLAg==",
-			"requires": {
-				"semver": "^5.4.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				}
-			}
 		},
 		"node-addon-api": {
 			"version": "4.2.0",
@@ -2951,11 +2837,6 @@
 			"integrity": "sha512-caJBVempXZPepZoZAPCWRTNxYQ+xtG/KAi4ozTA5A+nJ7IU+kLQCbqaUjb5Rwy14M9upBWiQ4NutcmW04LJSRw==",
 			"dev": true
 		},
-		"noop-logger": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-			"integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
-		},
 		"normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2982,21 +2863,11 @@
 				}
 			}
 		},
-		"npmlog": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"requires": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
-			}
-		},
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"nyc": {
 			"version": "15.1.0",
@@ -3422,38 +3293,6 @@
 				}
 			}
 		},
-		"prebuild-install": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.3.tgz",
-			"integrity": "sha512-GV+nsUXuPW2p8Zy7SarF/2W/oiK8bFQgJcncoJ0d7kRpekEA0ftChjfEaF9/Y+QJEc/wFR7RAEa8lYByuUIe2g==",
-			"requires": {
-				"detect-libc": "^1.0.3",
-				"expand-template": "^2.0.3",
-				"github-from-package": "0.0.0",
-				"minimist": "^1.2.0",
-				"mkdirp": "^0.5.1",
-				"napi-build-utils": "^1.0.1",
-				"node-abi": "^2.7.0",
-				"noop-logger": "^0.1.1",
-				"npmlog": "^4.0.1",
-				"pump": "^3.0.0",
-				"rc": "^1.2.7",
-				"simple-get": "^3.0.3",
-				"tar-fs": "^2.0.0",
-				"tunnel-agent": "^0.6.0",
-				"which-pm-runs": "^1.0.0"
-			},
-			"dependencies": {
-				"mkdirp": {
-					"version": "0.5.5",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-					"requires": {
-						"minimist": "^1.2.5"
-					}
-				}
-			}
-		},
 		"prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3542,17 +3381,6 @@
 			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
-			}
-		},
-		"rc": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"requires": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
 			}
 		},
 		"readable-stream": {
@@ -3690,7 +3518,8 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
 		},
 		"shebang-command": {
 			"version": "2.0.0",
@@ -3716,37 +3545,8 @@
 		"signal-exit": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
-		},
-		"simple-concat": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-			"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
-		},
-		"simple-get": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-			"integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
-			"requires": {
-				"decompress-response": "^4.2.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
-			},
-			"dependencies": {
-				"decompress-response": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-					"integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-					"requires": {
-						"mimic-response": "^2.0.0"
-					}
-				},
-				"mimic-response": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-					"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
-				}
-			}
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+			"dev": true
 		},
 		"sort-keys": {
 			"version": "1.1.2",
@@ -3826,6 +3626,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+			"dev": true,
 			"requires": {
 				"code-point-at": "^1.0.0",
 				"is-fullwidth-code-point": "^1.0.0",
@@ -3851,6 +3652,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -3868,11 +3670,6 @@
 			"requires": {
 				"is-natural-number": "^4.0.1"
 			}
-		},
-		"strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
 		"strip-outer": {
 			"version": "1.0.1",
@@ -3928,51 +3725,6 @@
 			"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
 			"requires": {
 				"has-flag": "^4.0.0"
-			}
-		},
-		"tar-fs": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
-			"integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
-			"requires": {
-				"chownr": "^1.1.1",
-				"mkdirp-classic": "^0.5.2",
-				"pump": "^3.0.0",
-				"tar-stream": "^2.0.0"
-			},
-			"dependencies": {
-				"bl": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-					"integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
-					"requires": {
-						"buffer": "^5.5.0",
-						"inherits": "^2.0.4",
-						"readable-stream": "^3.4.0"
-					}
-				},
-				"readable-stream": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				},
-				"tar-stream": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
-					"integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
-					"requires": {
-						"bl": "^4.0.1",
-						"end-of-stream": "^1.4.1",
-						"fs-constants": "^1.0.0",
-						"inherits": "^2.0.3",
-						"readable-stream": "^3.1.1"
-					}
-				}
 			}
 		},
 		"tar-stream": {
@@ -4074,14 +3826,6 @@
 				"escape-string-regexp": "^1.0.2"
 			}
 		},
-		"tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4149,13 +3893,12 @@
 			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
 		},
 		"usb": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/usb/-/usb-1.6.3.tgz",
-			"integrity": "sha512-23KYMjaWydACd8wgGKMQ4MNwFspAT6Xeim4/9Onqe5Rz/nMb4TM/WHL+qPT0KNFxzNKzAs63n1xQWGEtgaQ2uw==",
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/usb/-/usb-1.9.2.tgz",
+			"integrity": "sha512-dryNz030LWBPAf6gj8vyq0Iev3vPbCLHCT8dBw3gQRXRzVNsIdeuU+VjPp3ksmSPkeMAl1k+kQ14Ij0QHyeiAg==",
 			"requires": {
-				"bindings": "^1.4.0",
-				"nan": "2.13.2",
-				"prebuild-install": "^5.3.3"
+				"node-addon-api": "^4.2.0",
+				"node-gyp-build": "^4.3.0"
 			}
 		},
 		"util-deprecate": {
@@ -4194,15 +3937,11 @@
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 			"dev": true
 		},
-		"which-pm-runs": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-			"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
-		},
 		"wide-align": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+			"dev": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
 			}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -275,22 +275,6 @@
 			"integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
 			"dev": true
 		},
-		"@babel/runtime-corejs2": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.4.tgz",
-			"integrity": "sha512-9sArmpZDQsnR1yyAcU51DxQrntWxt0LUKjPp3pIyo7kVLfaqKt8muppcT87QmFkXV5H50qXAF8JWOjk0jaXRYA==",
-			"requires": {
-				"core-js": "^2.6.5",
-				"regenerator-runtime": "^0.13.4"
-			},
-			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.13.5",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-					"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
-				}
-			}
-		},
 		"@babel/template": {
 			"version": "7.14.5",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
@@ -673,9 +657,9 @@
 			"integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
 		},
 		"@types/node": {
-			"version": "13.11.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
-			"integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g=="
+			"version": "16.11.12",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+			"integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw=="
 		},
 		"@ungap/promise-all-settled": {
 			"version": "1.1.2",
@@ -806,11 +790,6 @@
 				"async-arrays": "*",
 				"extended-emitter": "*"
 			}
-		},
-		"assert-plus": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"assertion-error": {
 			"version": "1.1.0",
@@ -1826,11 +1805,6 @@
 				"wolfy87-eventemitter": "*"
 			}
 		},
-		"extsprintf": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz",
-			"integrity": "sha1-4mifjzVvrWLMplo6kcXfX5VRaS8="
-		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2350,11 +2324,6 @@
 				"from2": "^2.1.1",
 				"p-is-promise": "^1.1.0"
 			}
-		},
-		"ip": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
 		},
 		"is-binary-path": {
 			"version": "2.1.0",
@@ -2952,10 +2921,20 @@
 				}
 			}
 		},
+		"node-addon-api": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.2.0.tgz",
+			"integrity": "sha512-eazsqzwG2lskuzBqCGPi7Ac2UgOoMz8JVOXVhTvvPDYhthvNpefx8jWD8Np7Gv+2Sz0FlPWZk0nJV0z598Wn8Q=="
+		},
 		"node-fetch": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
 			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+		},
+		"node-gyp-build": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+			"integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
 		},
 		"node-preload": {
 			"version": "0.2.1",
@@ -3334,15 +3313,23 @@
 			}
 		},
 		"particle-usb": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-1.2.0.tgz",
-			"integrity": "sha512-45JfH45e3UaxiXB+y30h593VQeviZb94z6gzbJ+FH/gWTpDscL8uXyMzHeFyOSAgbl5tsqITyFJy0vuvvtatLQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-2.0.0.tgz",
+			"integrity": "sha512-eak87vRbd9N01YN+M6Yk72VN3BDY3dWd+yIiz5kLZolDp6B25qlz/R9Hi2dKMslUF8+Qm1B2AOC6DGi+hua/tQ==",
 			"requires": {
-				"@babel/runtime-corejs2": "^7.10.2",
-				"ip": "^1.1.5",
-				"protobufjs": "^6.8.9",
-				"usb": "^1.6.2",
-				"verror": "^1.10.0"
+				"protobufjs": "^6.11.2",
+				"usb": "^1.9.2"
+			},
+			"dependencies": {
+				"usb": {
+					"version": "1.9.2",
+					"resolved": "https://registry.npmjs.org/usb/-/usb-1.9.2.tgz",
+					"integrity": "sha512-dryNz030LWBPAf6gj8vyq0Iev3vPbCLHCT8dBw3gQRXRzVNsIdeuU+VjPp3ksmSPkeMAl1k+kQ14Ij0QHyeiAg==",
+					"requires": {
+						"node-addon-api": "^4.2.0",
+						"node-gyp-build": "^4.3.0"
+					}
+				}
 			}
 		},
 		"path-exists": {
@@ -3499,9 +3486,9 @@
 			"dev": true
 		},
 		"protobufjs": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.9.0.tgz",
-			"integrity": "sha512-LlGVfEWDXoI/STstRDdZZKb/qusoAWUnmLg9R8OLSO473mBLWHowx8clbX5/+mKDEI+v7GzjoK9tRPZMMcoTrg==",
+			"version": "6.11.2",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+			"integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
 			"requires": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
@@ -3514,7 +3501,7 @@
 				"@protobufjs/pool": "^1.1.0",
 				"@protobufjs/utf8": "^1.1.0",
 				"@types/long": "^4.0.1",
-				"@types/node": "^13.7.0",
+				"@types/node": ">=13.7.0",
 				"long": "^4.0.0"
 			}
 		},
@@ -4187,16 +4174,6 @@
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
-		},
-		"verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
-			}
 		},
 		"when": {
 			"version": "3.7.8",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 	},
 	"dependencies": {
 		"@octokit/rest": "^18.9.1",
+		"@particle/device-constants": "^1.3.0",
 		"binary-version-reader": "^1.0.0",
 		"chalk": "^3.0.0",
 		"decompress": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"semver": "^7.1.3",
 		"telnet-client": "^1.2.11",
 		"tmp": "^0.1.0",
-		"usb": "^1.6.2",
+		"usb": "^1.9.2",
 		"which": "^2.0.2"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"mkdirp": "^1.0.4",
 		"p-limit": "^2.3.0",
 		"particle-api-js": "^8.3.0",
-		"particle-usb": "^1.2.0",
+		"particle-usb": "^2.0.0",
 		"rimraf": "^3.0.2",
 		"semver": "^7.1.3",
 		"telnet-client": "^1.2.11",


### PR DESCRIPTION
This PR updates particle-usb to 2.0.0 and enables CI builds for Node 14 and 16. Note that unit tests in this repo fail intermittently on CI due to GitHub API rate limits. @joegoggins Perhaps we should add `GITHUB_TOKEN` to the repo secrets for the time being?