### PR TITLE
P2 support

### DIFF
--- a/lib/flasher.js
+++ b/lib/flasher.js
@@ -1,4 +1,4 @@
-const { platformForId, platformCommonsForMcu } = require('./platform');
+const { platformForId } = require('./platform');
 const { delay } = require('./util');
 
 const chalk = require('chalk');
@@ -78,7 +78,7 @@ class Flasher {
 					}
 					const m = modules[0];
 					if (this._platform.encryptedModules) {
-						if (this._platform.encryptedModules.find(el => (el.type == m.type && el.index == m.index))) {
+						if (this._platform.encryptedModules.find(el => (el.type === m.type && el.index === m.index))) {
 							if (!m.encrypted) {
 								this._log.warn(`Skipping ${m.file}. It's required to be encrypted`);
 								modules.shift();

--- a/lib/flasher.js
+++ b/lib/flasher.js
@@ -1,4 +1,4 @@
-const { platformForId } = require('./platform');
+const { platformForId, platformCommonsForMcu } = require('./platform');
 const { delay } = require('./util');
 
 const chalk = require('chalk');
@@ -77,6 +77,16 @@ class Flasher {
 						await this._dev.prepareToFlash();
 					}
 					const m = modules[0];
+					if (this._platform.encryptedModules) {
+						if (this._platform.encryptedModules.find(el => (el.type == m.type && el.index == m.index))) {
+							if (!m.encrypted) {
+								this._log.warn(`Skipping ${m.file}. It's required to be encrypted`);
+								modules.shift();
+								continue;
+							}
+						}
+					}
+
 					let file = m.file;
 					this._log.verbose('Flashing', path.basename(file));
 					if (m.dropHeader) {

--- a/lib/flasher.js
+++ b/lib/flasher.js
@@ -80,7 +80,7 @@ class Flasher {
 					if (this._platform.encryptedModules) {
 						if (this._platform.encryptedModules.find(el => (el.type === m.type && el.index === m.index))) {
 							if (!m.encrypted) {
-								this._log.warn(`Skipping ${m.file}. It's required to be encrypted`);
+								this._log.warn(`Skipping ${path.basename(m.file)}. It's required to be encrypted`);
 								modules.shift();
 								continue;
 							}

--- a/lib/module.js
+++ b/lib/module.js
@@ -407,6 +407,7 @@ class ModuleCache {
 			moduleSize: endAddr - startAddr + 4 /* CRC-32 */,
 			headerSize: MODULE_PREFIX_SIZE,
 			dropHeader: !!(info.moduleFlags & ModuleFlag.DROP_MODULE_INFO),
+			encrypted: !!(info.moduleFlags & ModuleFlag.ENCRYPTED),
 			crcValid,
 			fileSize,
 			file

--- a/lib/openocd.js
+++ b/lib/openocd.js
@@ -1,5 +1,5 @@
 const { Device, FlashInterface, StorageType } = require('./device');
-const { platformCommonsForGen } = require('./platform');
+const { platformCommonsForMcu } = require('./platform');
 const { delay, formatCommand, isSpace, isPrintable, toUInt32Hex } = require('./util');
 
 const usb = require('usb');
@@ -24,7 +24,7 @@ const ADAPTER_INFO = [
 		interfaceConfig: 'cmsis-dap.cfg',
 		serialParam: 'cmsis_dap_serial',
 		transport: 'swd',
-		platformGen: [3, 2]
+		platformMcu: ['nrf52840', 'stm32f2xx', 'rtl872x']
 	},
 	{
 		// Support for hs-probe: https://github.com/probe-rs/hs-probe
@@ -36,7 +36,7 @@ const ADAPTER_INFO = [
 		interfaceConfig: 'cmsis-dap.cfg',
 		serialParam: 'cmsis_dap_serial',
 		transport: 'swd',
-		platformGen: [3, 2]
+		platformMcu: ['nrf52840', 'stm32f2xx', 'rtl872x']
 	},
 	{
 		type: AdapterType.STLINK_V2,
@@ -46,7 +46,7 @@ const ADAPTER_INFO = [
 		interfaceConfig: 'stlink-v2.cfg', // Deprecated in recent versions of OpenOCD
 		serialParam: 'hla_serial',
 		transport: 'hla_swd',
-		platformGen: [2]
+		platformMcu: ['stm32f2xx']
 	}
 ];
 
@@ -65,6 +65,8 @@ const MAX_OPENOCD_RESTART_INTERVAL = 3000;
 const MIN_DEVICE_RESET_INTERVAL = 5000;
 
 const DEVICE_ID_SIZE = 24; // Hex-encoded
+
+const ARM_MAX_DEBUG_PORTS = 5;
 
 function makeUsbDeviceId(vendorId, productId) {
 	return [vendorId, productId].map(id => id.toString(16).padStart(4, '0')).join(':');
@@ -418,7 +420,7 @@ class OpenOcdDevice extends Device {
 					this._log.verbose('Retrying with asserted SRST');
 					platform = await this._detectPlatform({ assertSrst: true });
 				}
-				this._log.verbose('Target platform: Gen', platform.gen);
+				this._log.verbose(`Target platform: Gen ${platform.gen} (${platform.baseMcu})`);
 				this._target = platform.openOcd;
 			}
 			const cmds = [
@@ -479,13 +481,21 @@ class OpenOcdDevice extends Device {
 			throw new Error('Unsupported storage');
 		}
 		const addrStr = toUInt32Hex(address);
-		if (this._target.unlockFlash) {
-			const resp = await this._openocd.command(`flash write_image erase unlock ${file} ${addrStr}`, { timeout: FLASH_COMMAND_TIMEOUT });
-			if (!resp.match(/wrote \d+ bytes from file/i)) {
-				throw new Error('Programming failed' + ('\n' + resp).trimRight());
+		if (!this._target.flashWriteProcedure) {
+			if (this._target.unlockFlash) {
+				const resp = await this._openocd.command(`flash write_image erase unlock ${file} ${addrStr}`, { timeout: FLASH_COMMAND_TIMEOUT });
+				if (!resp.match(/wrote \d+ bytes from file/i)) {
+					throw new Error('Programming failed' + ('\n' + resp).trimRight());
+				}
+			} else {
+				const resp = await this._openocd.command(`program ${file} ${addrStr}`, { timeout: FLASH_COMMAND_TIMEOUT });
+				if (!resp.match(/\* Programming Finished \*/i)) {
+					throw new Error('Programming failed' + ('\n' + resp).trimRight());
+				}
 			}
 		} else {
-			const resp = await this._openocd.command(`program ${file} ${addrStr}`, { timeout: FLASH_COMMAND_TIMEOUT });
+			const cmd = this._target.flashWriteProcedure(file, addrStr);
+			const resp = await this._openocd.command(cmd, { timeout: FLASH_COMMAND_TIMEOUT });
 			if (!resp.match(/\* Programming Finished \*/i)) {
 				throw new Error('Programming failed' + ('\n' + resp).trimRight());
 			}
@@ -519,9 +529,9 @@ class OpenOcdDevice extends Device {
 
 	async _detectPlatform({ assertSrst = false } = {}) {
 		try {
-			const platformGen = this._info.platformGen;
-			if (platformGen.length === 1) {
-				return platformCommonsForGen(platformGen[0]);
+			const platformMcu = this._info.platformMcu;
+			if (platformMcu.length === 1) {
+				return platformCommonsForMcu(platformMcu[0]);
 			}
 			const trans = this._info.transport;
 			if (trans !== 'swd') {
@@ -548,11 +558,18 @@ class OpenOcdDevice extends Device {
 				'-c', cmds.join('; ')
 			];
 			await this._startOpenOcd(args, { resetAndHalt: assertSrst });
-			const resp = await this._openocd.command('dap info');
+			let resp = "";
+			for (let i = 0; i < ARM_MAX_DEBUG_PORTS; i++) {
+				const r = await this._openocd.command(`dap info ${i}`);
+				if (resp.match(/No AP found at this ap/i)) {
+					break;
+				}
+				resp += r;
+			}
 			let platform = null;
-			for (const gen of platformGen) {
+			for (const gen of platformMcu) {
 				// TODO: This will likely not work for future platforms
-				const p = platformCommonsForGen(gen);
+				const p = platformCommonsForMcu(gen);
 				if (resp.includes(p.openOcd.mcuManufacturer)) {
 					platform = p;
 					break;
@@ -571,12 +588,26 @@ class OpenOcdDevice extends Device {
 	}
 
 	async _getDeviceId() {
-		const addrStr = toUInt32Hex(this._target.deviceIdAddress);
 		const prefix = this._target.deviceIdPrefix || ''; // Hex-encoded
-		const size = Math.floor((DEVICE_ID_SIZE - prefix.length) / 2);
-		const resp = await this._openocd.command(`mdb ${addrStr} ${size}`);
-		const rx = new RegExp(`^${addrStr}:\\s((?:[0-9A-Za-z]{2}\\s?){${size}})$`);
-		const match = rx.exec(resp);
+		let match = null;
+		let resp;
+		if (this._target.deviceIdAddress) {
+				const addrStr = toUInt32Hex(this._target.deviceIdAddress);
+				const size = Math.floor((DEVICE_ID_SIZE - prefix.length) / 2);
+				resp = await this._openocd.command(`mdb ${addrStr} ${size}`);
+				const rx = new RegExp(`^${addrStr}:\\s((?:[0-9A-Za-z]{2}\\s?){${size}})$`);
+				match = rx.exec(resp);
+		} else if (this._target.deviceIdProcedure) {
+				resp = await this._openocd.command(this._target.deviceIdProcedure);
+				match = this._target.deviceIdRegex.exec(resp);
+				if (match && match.length > 1) {
+					// Fixup results a bit if regex got device id that consists of multiple parts
+					for (let i = 2; i < match.length; i++) {
+						match[1] += match[i];
+					}
+					match.length = 2;
+				} 
+		}
 		if (!match || match.length !== 2) {
 			throw new Error('Unable to read device ID' + ('\n' + resp).trimRight());
 		}
@@ -630,10 +661,14 @@ class OpenOcdDevice extends Device {
 		if (dt < MIN_DEVICE_RESET_INTERVAL) {
 			await delay(MIN_DEVICE_RESET_INTERVAL - dt);
 		}
-		const resp = await this._openocd.command('reset ' + mode);
-		if ((mode === 'init' || mode === 'halt') && !resp.match(/target halted due to/i)) {
-			this._log.debug('Falling back to soft reset and halt');
-			await this._openocd.command('soft_reset_halt');
+		if (mode == 'run' && this._target.resetRunProcedure) {
+			await this._openocd.command(this._target.resetRunProcedure);
+		} else {
+			const resp = await this._openocd.command('reset ' + mode);
+			if ((mode === 'init' || mode === 'halt') && !resp.match(/target halted due to/i)) {
+				this._log.debug('Falling back to soft reset and halt');
+				await this._openocd.command('soft_reset_halt');
+			}
 		}
 		this._lastReset = Date.now();
 	}

--- a/lib/openocd.js
+++ b/lib/openocd.js
@@ -558,7 +558,7 @@ class OpenOcdDevice extends Device {
 				'-c', cmds.join('; ')
 			];
 			await this._startOpenOcd(args, { resetAndHalt: assertSrst });
-			let resp = "";
+			let resp = '';
 			for (let i = 0; i < ARM_MAX_DEBUG_PORTS; i++) {
 				const r = await this._openocd.command(`dap info ${i}`);
 				if (resp.match(/No AP found at this ap/i)) {
@@ -592,21 +592,21 @@ class OpenOcdDevice extends Device {
 		let match = null;
 		let resp;
 		if (this._target.deviceIdAddress) {
-				const addrStr = toUInt32Hex(this._target.deviceIdAddress);
-				const size = Math.floor((DEVICE_ID_SIZE - prefix.length) / 2);
-				resp = await this._openocd.command(`mdb ${addrStr} ${size}`);
-				const rx = new RegExp(`^${addrStr}:\\s((?:[0-9A-Za-z]{2}\\s?){${size}})$`);
-				match = rx.exec(resp);
+			const addrStr = toUInt32Hex(this._target.deviceIdAddress);
+			const size = Math.floor((DEVICE_ID_SIZE - prefix.length) / 2);
+			resp = await this._openocd.command(`mdb ${addrStr} ${size}`);
+			const rx = new RegExp(`^${addrStr}:\\s((?:[0-9A-Za-z]{2}\\s?){${size}})$`);
+			match = rx.exec(resp);
 		} else if (this._target.deviceIdProcedure) {
-				resp = await this._openocd.command(this._target.deviceIdProcedure);
-				match = this._target.deviceIdRegex.exec(resp);
-				if (match && match.length > 1) {
-					// Fixup results a bit if regex got device id that consists of multiple parts
-					for (let i = 2; i < match.length; i++) {
-						match[1] += match[i];
-					}
-					match.length = 2;
-				} 
+			resp = await this._openocd.command(this._target.deviceIdProcedure);
+			match = this._target.deviceIdRegex.exec(resp);
+			if (match && match.length > 1) {
+				// Fixup results a bit if regex got device id that consists of multiple parts
+				for (let i = 2; i < match.length; i++) {
+					match[1] += match[i];
+				}
+				match.length = 2;
+			}
 		}
 		if (!match || match.length !== 2) {
 			throw new Error('Unable to read device ID' + ('\n' + resp).trimRight());
@@ -661,7 +661,7 @@ class OpenOcdDevice extends Device {
 		if (dt < MIN_DEVICE_RESET_INTERVAL) {
 			await delay(MIN_DEVICE_RESET_INTERVAL - dt);
 		}
-		if (mode == 'run' && this._target.resetRunProcedure) {
+		if (mode === 'run' && this._target.resetRunProcedure) {
 			await this._openocd.command(this._target.resetRunProcedure);
 		} else {
 			const resp = await this._openocd.command('reset ' + mode);

--- a/lib/openocd.js
+++ b/lib/openocd.js
@@ -420,7 +420,7 @@ class OpenOcdDevice extends Device {
 					this._log.verbose('Retrying with asserted SRST');
 					platform = await this._detectPlatform({ assertSrst: true });
 				}
-				this._log.verbose(`Target platform: Gen ${platform.gen} (${platform.baseMcu})`);
+				this._log.verbose(`Target platform: ${platform.baseMcu}`);
 				this._target = platform.openOcd;
 			}
 			const cmds = [
@@ -561,7 +561,7 @@ class OpenOcdDevice extends Device {
 			let resp = '';
 			for (let i = 0; i < ARM_MAX_DEBUG_PORTS; i++) {
 				const r = await this._openocd.command(`dap info ${i}`);
-				if (resp.match(/No AP found at this ap/i)) {
+				if (r.match(/No AP found at this ap/i)) {
 					break;
 				}
 				resp += r;

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -4,7 +4,6 @@ const _ = require('lodash');
 
 const PLATFORM_COMMONS = [
 	{
-		gen: 2,
 		baseMcu: 'stm32f2xx',
 		internalFlash: {
 			dfuAltSetting: 0
@@ -27,7 +26,6 @@ const PLATFORM_COMMONS = [
 		}
 	},
 	{
-		gen: 3,
 		baseMcu: 'nrf52840',
 		hasRadioStack: true,
 		internalFlash: {
@@ -53,7 +51,6 @@ const PLATFORM_COMMONS = [
 		}
 	},
 	{
-		gen: 3,
 		baseMcu: 'rtl872x',
 		internalFlash: {
 			dfuAltSetting: 0
@@ -85,7 +82,7 @@ const PLATFORM_COMMONS = [
 			deviceIdRegex: new RegExp(`MAC:\\s([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2})`),
 			// FIXME: verification is disabled, it fails on some versions of OpenOCD
 			flashWriteProcedure: (binary, address) => {
-				return `rtl872x_flash_write_bin_ext ${binary} ${address} 1 0`;
+				return `rtl872x_flash_write_bin_ext ${binary} ${address} 1 1`;
 			},
 			resetRunProcedure: 'rtl872x_wdg_reset',
 		}
@@ -100,28 +97,24 @@ const PLATFORMS = [
 		id: 6,
 		name: 'photon',
 		displayName: 'Photon',
-		gen: 2,
 		baseMcu: 'stm32f2xx'
 	},
 	{
 		id: 8,
 		name: 'p1',
 		displayName: 'P1',
-		gen: 2,
 		baseMcu: 'stm32f2xx'
 	},
 	{
 		id: 10,
 		name: 'electron',
 		displayName: 'Electron',
-		gen: 2,
 		baseMcu: 'stm32f2xx'
 	},
 	{
 		id: 12,
 		name: 'argon',
 		displayName: 'Argon',
-		gen: 3,
 		baseMcu: 'nrf52840',
 		hasNcpFirmware: true
 	},
@@ -129,21 +122,18 @@ const PLATFORMS = [
 		id: 13,
 		name: 'boron',
 		displayName: 'Boron',
-		gen: 3,
 		baseMcu: 'nrf52840'
 	},
 	{
 		id: 14,
 		name: 'xenon',
 		displayName: 'Xenon',
-		gen: 3,
 		baseMcu: 'nrf52840'
 	},
 	{
 		id: 22,
 		name: 'asom',
 		displayName: 'A SoM',
-		gen: 3,
 		baseMcu: 'nrf52840',
 		hasNcpFirmware: true
 	},
@@ -151,14 +141,12 @@ const PLATFORMS = [
 		id: 23,
 		name: 'bsom',
 		displayName: 'B SoM',
-		gen: 3,
 		baseMcu: 'nrf52840'
 	},
 	{
 		id: 25,
 		name: 'b5som',
 		displayName: 'B5 SoM',
-		gen: 3,
 		baseMcu: 'nrf52840',
 		filesystem: {
 			size: 4 * 1024 * 1024
@@ -168,7 +156,6 @@ const PLATFORMS = [
 		id: 26,
 		name: 'tracker',
 		displayName: 'Tracker',
-		gen: 3,
 		baseMcu: 'nrf52840',
 		filesystem: {
 			size: 4 * 1024 * 1024
@@ -178,7 +165,6 @@ const PLATFORMS = [
 		id: 32,
 		name: 'p2',
 		displayName: 'P2',
-		gen: 3,
 		baseMcu: 'rtl872x',
 		filesystem: {
 			size: 8 * 1024 * 1024

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 const PLATFORM_COMMONS = [
 	{
 		gen: 2,
+		baseMcu: 'stm32f2xx',
 		internalFlash: {
 			dfuAltSetting: 0
 		},
@@ -27,6 +28,7 @@ const PLATFORM_COMMONS = [
 	},
 	{
 		gen: 3,
+		baseMcu: 'nrf52840',
 		hasRadioStack: true,
 		internalFlash: {
 			dfuAltSetting: 0
@@ -49,10 +51,46 @@ const PLATFORM_COMMONS = [
 			deviceIdAddress: 0x10000060, // FICR
 			deviceIdPrefix: 'e00fce68'
 		}
-	}
+	},
+	{
+		gen: 3,
+		baseMcu: 'rtl872x',
+		internalFlash: {
+			dfuAltSetting: 0
+		},
+		externalFlash: {
+			dfuAltSetting: 2
+		},
+		dct: {
+			dfuAltSetting: 1,
+			storage: StorageType.FILESYSTEM
+		},
+		filesystem: {
+			storage: StorageType.EXTERNAL_FLASH,
+			address: 0x08600000,
+			size: 2 * 1024 * 1024
+		},
+		encryptedModules: [
+			{
+				// MBR is expected to be encrypted
+				index: 1,
+				type: 'bootloader'
+			}
+		],
+		openOcd: {
+			targetConfig: 'rtl872x.tcl',
+			mcuManufacturer: 'Realtek',
+			deviceIdProcedure: "rtl872x_read_efuse_mac; rtl872x_wdg_reset",
+			deviceIdPrefix: '0a10aced2021',
+			deviceIdRegex: new RegExp(`MAC:\\s([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2})`),
+			// FIXME: verification is disabled, it fails on some versions of OpenOCD
+			flashWriteProcedure: (binary, address) => { return `rtl872x_flash_write_bin_ext ${binary} ${address} 1 0`; },
+			resetRunProcedure: 'rtl872x_wdg_reset',
+		}
+	},
 ];
 
-const PLATFORM_COMMONS_BY_GEN = PLATFORM_COMMONS.reduce((map, p) => map.set(p.gen, p), new Map());
+const PLATFORM_COMMONS_BY_MCU = PLATFORM_COMMONS.reduce((map, p) => map.set(p.baseMcu, p), new Map());
 
 // Supported Device OS platforms
 const PLATFORMS = [
@@ -60,57 +98,66 @@ const PLATFORMS = [
 		id: 6,
 		name: 'photon',
 		displayName: 'Photon',
-		gen: 2
+		gen: 2,
+		baseMcu: 'stm32f2xx'
 	},
 	{
 		id: 8,
 		name: 'p1',
 		displayName: 'P1',
-		gen: 2
+		gen: 2,
+		baseMcu: 'stm32f2xx'
 	},
 	{
 		id: 10,
 		name: 'electron',
 		displayName: 'Electron',
-		gen: 2
+		gen: 2,
+		baseMcu: 'stm32f2xx'
 	},
 	{
 		id: 12,
 		name: 'argon',
 		displayName: 'Argon',
 		gen: 3,
+		baseMcu: 'nrf52840',
 		hasNcpFirmware: true
 	},
 	{
 		id: 13,
 		name: 'boron',
 		displayName: 'Boron',
-		gen: 3
+		gen: 3,
+		baseMcu: 'nrf52840'
 	},
 	{
 		id: 14,
 		name: 'xenon',
 		displayName: 'Xenon',
-		gen: 3
+		gen: 3,
+		baseMcu: 'nrf52840'
 	},
 	{
 		id: 22,
 		name: 'asom',
 		displayName: 'A SoM',
 		gen: 3,
+		baseMcu: 'nrf52840',
 		hasNcpFirmware: true
 	},
 	{
 		id: 23,
 		name: 'bsom',
 		displayName: 'B SoM',
-		gen: 3
+		gen: 3,
+		baseMcu: 'nrf52840'
 	},
 	{
 		id: 25,
 		name: 'b5som',
 		displayName: 'B5 SoM',
 		gen: 3,
+		baseMcu: 'nrf52840',
 		filesystem: {
 			size: 4 * 1024 * 1024
 		}
@@ -120,11 +167,22 @@ const PLATFORMS = [
 		name: 'tracker',
 		displayName: 'Tracker',
 		gen: 3,
+		baseMcu: 'nrf52840',
 		filesystem: {
 			size: 4 * 1024 * 1024
 		}
+	},
+	{
+		id: 32,
+		name: 'p2',
+		displayName: 'P2',
+		gen: 3,
+		baseMcu: 'rtl872x',
+		filesystem: {
+			size: 8 * 1024 * 1024
+		}
 	}
-].map(p => _.merge({}, PLATFORM_COMMONS_BY_GEN.get(p.gen), p));
+].map(p => _.merge({}, PLATFORM_COMMONS_BY_MCU.get(p.baseMcu), p));
 
 const PLATFORMS_BY_ID = PLATFORMS.reduce((map, p) => map.set(p.id, p), new Map());
 const PLATFORMS_BY_NAME = PLATFORMS.reduce((map, p) => map.set(p.name, p), new Map());
@@ -145,8 +203,8 @@ function platformForName(name) {
 	return p;
 }
 
-function platformCommonsForGen(gen) {
-	const p = PLATFORM_COMMONS_BY_GEN.get(gen);
+function platformCommonsForMcu(mcu) {
+	const p = PLATFORM_COMMONS_BY_MCU.get(mcu);
 	if (!p) {
 		throw new RangeError('Hello from 2020!');
 	}
@@ -157,5 +215,5 @@ module.exports = {
 	PLATFORMS,
 	platformForId,
 	platformForName,
-	platformCommonsForGen
+	platformCommonsForMcu
 };

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -80,11 +80,13 @@ const PLATFORM_COMMONS = [
 		openOcd: {
 			targetConfig: 'rtl872x.tcl',
 			mcuManufacturer: 'Realtek',
-			deviceIdProcedure: "rtl872x_read_efuse_mac; rtl872x_wdg_reset",
+			deviceIdProcedure: 'rtl872x_read_efuse_mac; rtl872x_wdg_reset',
 			deviceIdPrefix: '0a10aced2021',
 			deviceIdRegex: new RegExp(`MAC:\\s([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2})`),
 			// FIXME: verification is disabled, it fails on some versions of OpenOCD
-			flashWriteProcedure: (binary, address) => { return `rtl872x_flash_write_bin_ext ${binary} ${address} 1 0`; },
+			flashWriteProcedure: (binary, address) => {
+				return `rtl872x_flash_write_bin_ext ${binary} ${address} 1 0`;
+			},
 			resetRunProcedure: 'rtl872x_wdg_reset',
 		}
 	},

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -834,12 +834,11 @@
 			"dev": true
 		},
 		"binary-version-reader": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/binary-version-reader/-/binary-version-reader-1.0.0.tgz",
-			"integrity": "sha512-lbY2OHH1iit4BLk20EhIqOR4nHxuDLgGLl217a4etr2oR/dfezXg+3UJ6pFWISFoaF0uswEVORwXg3T4K9qkCQ==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/binary-version-reader/-/binary-version-reader-1.1.2.tgz",
+			"integrity": "sha512-C004qSxo7hUBNufccaOijzj0LCBKod32AT+cYUVGbV6fIfUq2nSlIWZMd/gnJqHKEEuo2dgFTayPwp6kRWt4ag==",
 			"requires": {
 				"buffer-crc32": "^0.2.5",
-				"h5.buffers": "^0.1.1",
 				"when": "^3.7.3",
 				"xtend": "^4.0.2"
 			}
@@ -2122,11 +2121,6 @@
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
-		},
-		"h5.buffers": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/h5.buffers/-/h5.buffers-0.1.1.tgz",
-			"integrity": "sha1-JEh3MFMOSwDkm1rxcEldrPpAEb4="
 		},
 		"has-flag": {
 			"version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	"dependencies": {
 		"@octokit/rest": "^18.9.1",
 		"@particle/device-constants": "^1.3.0",
-		"binary-version-reader": "^1.0.0",
+		"binary-version-reader": "^1.1.2",
 		"chalk": "^3.0.0",
 		"decompress": "^4.2.1",
 		"download": "^8.0.0",


### PR DESCRIPTION
### Description

Adds P2 support. https://github.com/particle-iot/firmware-private/tree/feature/device-os-flash-util branch has to be used and `OPENOCD_SCRIPTS` env variable needs to be configured to point to `scripts` folder in Device OS source tree.

Latest OpenOCD should also be used 0.11.0+.

To test for example run:
```
OPENOCD_SCRIPTS=/path/to/device-os/scripts device-os-flash --all-devices /path/to/3.0.1-p2.5/p2 --openocd
```