### PR TITLE
Use platform definitions from device-constants

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -81,7 +81,7 @@ class App {
 		devs = await this._getTargetDevices(devs, devArgs);
 		// Flash module binaries
 		this._log.info('Flashing target devices');
-		await this._flashDevices(devs, modules, { maxRetries, maxJobs, factoryReset: args['factory-reset'] });
+		await this._flashDevices(devs, modules, { maxRetries, maxJobs });
 		this._log.info('Done');
 	}
 
@@ -112,7 +112,7 @@ class App {
 		}
 	}
 
-	async _flashDevices(devs, modules, { maxRetries = 0, maxJobs = Infinity, factoryReset = false } = {}) {
+	async _flashDevices(devs, modules, { maxRetries = 0, maxJobs = Infinity } = {}) {
 		const flashers = [];
 		this._log.verbose('Target devices:');
 		for (let i = 0; i < devs.length; ++i) {
@@ -136,7 +136,7 @@ class App {
 		const limit = pLimit(maxJobs);
 		const promises = flashers.map(f => limit(async () => {
 			try {
-				await f.run(modules, { maxRetries, factoryReset });
+				await f.run(modules, { maxRetries });
 			} catch (err) {
 				f.log.error(err.message);
 				if (!error) {
@@ -353,20 +353,19 @@ class App {
 
 	_parseVersionOrPathArg(args) {
 		let arg = args._[0];
-		if (arg) {
-			if (fs.existsSync(arg)) {
-				arg = { path: arg };
-			} else {
-				if (arg.startsWith('v')) {
-					arg = arg.slice(1);
-				}
-				if (!semver.valid(arg)) {
-					throw new RangeError(`Invalid version number: ${args._[0]}`);
-				}
-				arg = { version: arg };
-			}
-		} else if (!args['factory-reset']) {
+		if (!arg) {
 			throw new Error('Device OS version is not specified');
+		}
+		if (fs.existsSync(arg)) {
+			arg = { path: arg };
+		} else {
+			if (arg.startsWith('v')) {
+				arg = arg.slice(1);
+			}
+			if (!semver.valid(arg)) {
+				throw new RangeError(`Invalid version number: ${args._[0]}`);
+			}
+			arg = { version: arg };
 		}
 		return arg;
 	}

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,10 +1,10 @@
 const { OpenOcdFlashInterface } = require('./openocd');
 const { DfuFlashInterface } = require('./dfu');
 const { UsbFlashInterface } = require('./usb');
-const { ModuleCache, ModuleType } = require('./module');
+const { ModuleCache } = require('./module');
 const { ParticleApi } = require('./api');
 const { Flasher } = require('./flasher');
-const { platformForId, platformForName } = require('./platform');
+const { platformForId, platformForName, ModuleType } = require('./platform');
 const { isDeviceId } = require('./util');
 
 const usb = require('particle-usb');

--- a/lib/device.js
+++ b/lib/device.js
@@ -3,8 +3,7 @@ const EventEmitter = require('events');
 const StorageType = {
 	INTERNAL_FLASH: 'internal_flash',
 	EXTERNAL_FLASH: 'external_flash',
-	FILESYSTEM: 'filesystem',
-	OTHER: 'other'
+	EXTERNAL_MCU: 'external_mcu'
 };
 
 class Device extends EventEmitter {

--- a/lib/device.js
+++ b/lib/device.js
@@ -1,11 +1,5 @@
 const EventEmitter = require('events');
 
-const StorageType = {
-	INTERNAL_FLASH: 'internal_flash',
-	EXTERNAL_FLASH: 'external_flash',
-	EXTERNAL_MCU: 'external_mcu'
-};
-
 class Device extends EventEmitter {
 	constructor({ id, platformId, log }) {
 		super();
@@ -93,7 +87,6 @@ class FlashInterface {
 }
 
 module.exports = {
-	StorageType,
 	Device,
 	FlashInterface
 };

--- a/lib/dfu.js
+++ b/lib/dfu.js
@@ -1,7 +1,6 @@
-const { Device, FlashInterface, StorageType } = require('./device');
+const { Device, FlashInterface } = require('./device');
 const { openUsbDeviceById } = require('./usb');
-const { ModuleType } = require('./module');
-const { platformForId } = require('./platform');
+const { platformForId, ModuleType } = require('./platform');
 const { execCommand, formatCommand, toUInt32Hex, toUInt16Hex } = require('./util');
 
 const usb = require('particle-usb');
@@ -58,7 +57,7 @@ class DfuDevice extends Device {
 	}
 
 	async writeToFlash(file, storage, address) {
-		const alt = this._altSettingForStorage(storage);
+		const alt = this._platform.dfuAltSettingForStorage(storage);
 		if (alt === null) {
 			throw new Error('Unsupported storage');
 		}
@@ -102,28 +101,8 @@ class DfuDevice extends Device {
 	}
 
 	canWriteToFlash(storage) {
-		const alt = this._altSettingForStorage(storage);
+		const alt = this._platform.dfuAltSettingForStorage(storage);
 		return (alt !== null);
-	}
-
-	_altSettingForStorage(storage) {
-		let storageStr; // Storage type as defined in device-constants
-		switch (storage) {
-			case StorageType.INTERNAL_FLASH:
-				storageStr = 'internalFlash';
-				break;
-			case StorageType.EXTERNAL_FLASH:
-				storageStr = 'externalFlash';
-				break;
-		}
-		if (!storageStr) {
-			return null;
-		}
-		const storageInfo = this._platform.dfu.storage.find(s => s.type === storageStr);
-		if (!storageInfo) {
-			return null;
-		}
-		return storageInfo.alt;
 	}
 }
 

--- a/lib/dfu.js
+++ b/lib/dfu.js
@@ -59,7 +59,7 @@ class DfuDevice extends Device {
 
 	async writeToFlash(file, storage, address) {
 		const alt = this._altSettingForStorage(storage);
-		if (alt === undefined) {
+		if (alt === null) {
 			throw new Error('Unsupported storage');
 		}
 		const dev = this._dev;
@@ -103,20 +103,27 @@ class DfuDevice extends Device {
 
 	canWriteToFlash(storage) {
 		const alt = this._altSettingForStorage(storage);
-		return (alt !== undefined);
+		return (alt !== null);
 	}
 
 	_altSettingForStorage(storage) {
-		let alt = undefined;
+		let storageStr; // Storage type as defined in device-constants
 		switch (storage) {
 			case StorageType.INTERNAL_FLASH:
-				alt = this._platform.internalFlash.dfuAltSetting;
+				storageStr = 'internalFlash';
 				break;
 			case StorageType.EXTERNAL_FLASH:
-				alt = this._platform.externalFlash.dfuAltSetting;
+				storageStr = 'externalFlash';
 				break;
 		}
-		return alt;
+		if (!storageStr) {
+			return null;
+		}
+		const storageInfo = this._platform.dfu.storage.find(s => s.type === storageStr);
+		if (!storageInfo) {
+			return null;
+		}
+		return storageInfo.alt;
 	}
 }
 

--- a/lib/flasher.js
+++ b/lib/flasher.js
@@ -24,10 +24,10 @@ class Flasher {
 		this._retriesLeft = 0;
 	}
 
-	async run(modules, { maxRetries = 0, factoryReset = false } = {}) {
+	async run(modules, { maxRetries = 0 } = {}) {
 		// Filter modules by target platform
 		modules = modules.filter(m => m.platformId === this._dev.platformId);
-		if (!modules.length && !factoryReset) {
+		if (!modules.length) {
 			this._log.warn('Module list is empty');
 			return;
 		}
@@ -49,9 +49,6 @@ class Flasher {
 				this._log.verbose('Using control requests to flash remaining modules');
 			}
 			await this._updateModules(otaModules);
-		}
-		if (factoryReset) {
-			await this._factoryReset();
 		}
 		this._log.verbose(chalk.green.bold('Flashed successfully'));
 	}
@@ -159,79 +156,6 @@ class Flasher {
 					if (!modules.length && dev) {
 						needReset = true;
 					}
-				}
-				if (needReset) {
-					this._log.verbose('Resetting device');
-					await dev.reset();
-					needReset = false;
-				}
-			} catch (err) {
-				if (dev) {
-					await dev.close();
-					dev = null;
-				}
-				if (!this._retriesLeft) {
-					throw err;
-				}
-				this._log.warn(err.message);
-				this._log.warn('Retrying');
-				--this._retriesLeft;
-			}
-		}
-		if (dev) {
-			await dev.close();
-		}
-	}
-
-	async _factoryReset() {
-		const fs = this._platform.filesystem;
-		const dct = this._platform.dct;
-		let eraseFs = !!fs;
-		let eraseDct = !!dct;
-		let needReset = false;
-		let dev = null;
-		for (;;) {
-			try {
-				if (!eraseFs && !eraseDct && !needReset) {
-					break;
-				}
-				let prepare = false;
-				if (!dev) {
-					await delay(REOPEN_DELAY);
-					dev = await this._dfu.openDeviceById(this._dev.id, { timeout: REOPEN_TIMEOUT });
-					dev.log = this._log;
-					prepare = true;
-					if (eraseFs && !dev.canWriteToFlash(fs.storage)) {
-						eraseFs = false;
-					}
-					if (eraseDct && !dev.canWriteToFlash(dct.storage)) {
-						eraseDct = false;
-					}
-				}
-				if (eraseFs || eraseDct) {
-					if (prepare) {
-						this._log.verbose('Preparing device for flashing');
-						await dev.prepareToFlash();
-					}
-					if (eraseFs) {
-						this._log.verbose('Erasing filesystem');
-						const file = this._genBlankFile(fs.size);
-						let t = Date.now();
-						await dev.writeToFlash(file, fs.storage, fs.address);
-						t = Math.round((Date.now() - t) / 100) / 10;
-						this._log.debug(`Erased in ${t}s`);
-						eraseFs = false;
-					}
-					if (eraseDct) {
-						this._log.verbose('Erasing DCT');
-						const file = this._genBlankFile(dct.size);
-						let t = Date.now();
-						await dev.writeToFlash(file, dct.storage, dct.address);
-						t = Math.round((Date.now() - t) / 100) / 10;
-						this._log.debug(`Erased in ${t}s`);
-						eraseDct = false;
-					}
-					needReset = true;
 				}
 				if (needReset) {
 					this._log.verbose('Resetting device');

--- a/lib/flasher.js
+++ b/lib/flasher.js
@@ -1,4 +1,3 @@
-const { platformForId } = require('./platform');
 const { delay } = require('./util');
 
 const chalk = require('chalk');
@@ -18,7 +17,6 @@ class Flasher {
 		this._tempDir = tempDir;
 		this._name = name;
 		this._dev = device;
-		this._platform = platformForId(device.platformId);
 		this._dfu = dfu;
 		this._usb = usb;
 		this._retriesLeft = 0;
@@ -74,16 +72,11 @@ class Flasher {
 						await this._dev.prepareToFlash();
 					}
 					const m = modules[0];
-					if (this._platform.encryptedModules) {
-						if (this._platform.encryptedModules.find(el => (el.type === m.type && el.index === m.index))) {
-							if (!m.encrypted) {
-								this._log.warn(`Skipping ${path.basename(m.file)}. It's required to be encrypted`);
-								modules.shift();
-								continue;
-							}
-						}
+					if (m.needsToBeEncrypted && !m.encrypted) {
+						this._log.warn(`Skipping ${path.basename(m.file)}. It's required to be encrypted`);
+						modules.shift();
+						continue;
 					}
-
 					let file = m.file;
 					this._log.verbose('Flashing', path.basename(file));
 					if (m.dropHeader) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -170,7 +170,7 @@ async function run() {
 		const moduleArgs = parseModuleTypeArgs(args);
 		args = parseArgs(args, {
 			string: ['_', 'device'],
-			boolean: ['all-devices', 'openocd', 'factory-reset', 'draft', 'cache', 'version', 'help'],
+			boolean: ['all-devices', 'openocd', 'draft', 'cache', 'version', 'help'],
 			alias: {
 				'device': 'd',
 				'retries': 'r',

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,5 +1,4 @@
-const { platformForId } = require('./platform');
-const { StorageType } = require('./device');
+const { platformForId, ModuleType } = require('./platform');
 
 const { HalModuleParser, ModuleInfo } = require('binary-version-reader');
 const { Octokit } = require('@octokit/rest');
@@ -26,14 +25,6 @@ const {
 	Flags: ModuleFlag,
 	MODULE_PREFIX_SIZE
 } = ModuleInfo;
-
-const ModuleType = {
-	USER_PART: 'user_part',
-	SYSTEM_PART: 'system_part',
-	BOOTLOADER: 'bootloader',
-	RADIO_STACK: 'radio_stack',
-	NCP_FIRMWARE: 'ncp_firmware'
-};
 
 class ModuleCache {
 	constructor({ cacheDir, tempDir, log }) {
@@ -357,7 +348,41 @@ class ModuleCache {
 		}
 		info = info.prefixInfo;
 		const platform = platformForId(info.platformID);
-		const { type, storage } = this._getModuleTypeAndStorage(info, platform);
+		let type = null;
+		switch (info.moduleFunction) {
+			case ModuleFunction.BOOTLOADER: {
+				type = ModuleType.BOOTLOADER;
+				break;
+			}
+			case ModuleFunction.SYSTEM_PART: {
+				type = ModuleType.SYSTEM_PART;
+				break;
+			}
+			case ModuleFunction.USER_PART: {
+				type = ModuleType.USER_PART;
+				break;
+			}
+			case ModuleFunction.NCP_FIRMWARE: {
+				type = ModuleType.NCP_FIRMWARE;
+				break;
+			}
+			case ModuleFunction.RADIO_STACK: {
+				type = ModuleType.RADIO_STACK;
+				break;
+			}
+			case ModuleFunction.MONO_FIRMWARE:
+			case ModuleFunction.RESOURCE:
+			case ModuleFunction.SETTINGS: {
+				throw new Error(`Unsupported module function: ${info.moduleFunction}`);
+			}
+			default: {
+				throw new Error(`Unknown module function: ${info.moduleFunction}`);
+			}
+		}
+		const storageInfo = platform.storageForFirmwareModule(type, info.moduleIndex);
+		if (!storageInfo) {
+			throw new Error('Cannot determine storage device for firmware module');
+		}
 		const startAddr = Number.parseInt(info.moduleStartAddy, 16);
 		const endAddr = Number.parseInt(info.moduleEndAddy, 16);
 		const fileSize = fs.statSync(file).size;
@@ -366,12 +391,13 @@ class ModuleCache {
 			type,
 			index: info.moduleIndex,
 			version: info.moduleVersion,
-			storage,
+			storage: storageInfo.type,
 			address: startAddr,
 			moduleSize: endAddr - startAddr + 4 /* CRC-32 */,
 			headerSize: MODULE_PREFIX_SIZE,
 			dropHeader: !!(info.moduleFlags & ModuleFlag.DROP_MODULE_INFO),
 			encrypted: !!(info.moduleFlags & ModuleFlag.ENCRYPTED),
+			needsToBeEncrypted: storageInfo.encrypted,
 			crcValid,
 			fileSize,
 			file
@@ -381,77 +407,6 @@ class ModuleCache {
 			m.headerSize = ModuleInfo.HEADER_SIZE;
 		}
 		return m;
-	}
-
-	_getModuleTypeAndStorage(moduleInfo, platform) {
-		let type; // Internal module type
-		let typeStr; // Module type as defined in device-constants
-		switch (moduleInfo.moduleFunction) {
-			case ModuleFunction.BOOTLOADER: {
-				type = ModuleType.BOOTLOADER;
-				typeStr = (moduleInfo.moduleIndex === 0) ? 'bootloader' : 'prebootloader';
-				break;
-			}
-			case ModuleFunction.SYSTEM_PART: {
-				type = ModuleType.SYSTEM_PART;
-				switch (moduleInfo.moduleIndex) {
-					case 1:
-						typeStr = 'systemPart';
-						break;
-					case 2:
-						typeStr = 'systemPart2';
-						break;
-					case 3:
-						typeStr = 'systemPart3';
-						break;
-					default:
-						throw new Error(`Unexpected index of a system part module: ${moduleInfo.moduleIndex}`);
-				}
-				break;
-			}
-			case ModuleFunction.USER_PART: {
-				type = ModuleType.USER_PART;
-				typeStr = 'userPart';
-				break;
-			}
-			case ModuleFunction.NCP_FIRMWARE: {
-				type = ModuleType.NCP_FIRMWARE;
-				typeStr = 'ncpFirmware';
-				break;
-			}
-			case ModuleFunction.RADIO_STACK: {
-				type = ModuleType.RADIO_STACK;
-				typeStr = 'radioStack';
-				break;
-			}
-			case ModuleFunction.MONO_FIRMWARE:
-			case ModuleFunction.RESOURCE:
-			case ModuleFunction.SETTINGS: {
-				throw new Error(`Unsupported module function: ${moduleInfo.moduleFunction}`);
-			}
-			default: {
-				throw new Error(`Unknown module function: ${moduleInfo.moduleFunction}`);
-			}
-		}
-		moduleInfo = platform.firmwareModules.find(m => m.type === typeStr);
-		if (!moduleInfo) {
-			throw new Error(`Cannot determine storage for module type: ${typeStr}`);
-		}
-		let storage; // Internal storage type
-		switch (moduleInfo.storage) {
-			case 'internalFlash':
-				storage = StorageType.INTERNAL_FLASH;
-				break;
-			case 'externalFlash':
-				storage = StorageType.EXTERNAL_FLASH;
-				break;
-			case 'externalMcu':
-				storage = StorageType.EXTERNAL_MCU;
-				break;
-			default:
-				throw new Error(`Unknown module storage: ${moduleInfo.storage}`);
-		}
-		return { type, storage };
 	}
 
 	async _listOlderReleaseVersions(version) {
@@ -507,6 +462,5 @@ class ModuleCache {
 }
 
 module.exports = {
-	ModuleType,
 	ModuleCache
 };

--- a/lib/module.js
+++ b/lib/module.js
@@ -357,43 +357,7 @@ class ModuleCache {
 		}
 		info = info.prefixInfo;
 		const platform = platformForId(info.platformID);
-		let type = null;
-		let storage = null;
-		switch (info.moduleFunction) {
-			case ModuleFunction.BOOTLOADER: {
-				type = ModuleType.BOOTLOADER;
-				storage = StorageType.INTERNAL_FLASH;
-				break;
-			}
-			case ModuleFunction.SYSTEM_PART: {
-				type = ModuleType.SYSTEM_PART;
-				storage = StorageType.INTERNAL_FLASH;
-				break;
-			}
-			case ModuleFunction.USER_PART: {
-				type = ModuleType.USER_PART;
-				storage = StorageType.INTERNAL_FLASH;
-				break;
-			}
-			case ModuleFunction.NCP_FIRMWARE: {
-				type = ModuleType.NCP_FIRMWARE;
-				storage = StorageType.OTHER;
-				break;
-			}
-			case ModuleFunction.RADIO_STACK: {
-				type = ModuleType.RADIO_STACK;
-				storage = StorageType.INTERNAL_FLASH;
-				break;
-			}
-			case ModuleFunction.MONO_FIRMWARE:
-			case ModuleFunction.RESOURCE:
-			case ModuleFunction.SETTINGS: {
-				throw new Error('Unsupported module type');
-			}
-			default: {
-				throw new Error(`Unknown module function: ${info.moduleFunction}`);
-			}
-		}
+		const { type, storage } = this._getModuleTypeAndStorage(info, platform);
 		const startAddr = Number.parseInt(info.moduleStartAddy, 16);
 		const endAddr = Number.parseInt(info.moduleEndAddy, 16);
 		const fileSize = fs.statSync(file).size;
@@ -417,6 +381,77 @@ class ModuleCache {
 			m.headerSize = ModuleInfo.HEADER_SIZE;
 		}
 		return m;
+	}
+
+	_getModuleTypeAndStorage(moduleInfo, platform) {
+		let type; // Internal module type
+		let typeStr; // Module type as defined in device-constants
+		switch (moduleInfo.moduleFunction) {
+			case ModuleFunction.BOOTLOADER: {
+				type = ModuleType.BOOTLOADER;
+				typeStr = (moduleInfo.moduleIndex === 0) ? 'bootloader' : 'prebootloader';
+				break;
+			}
+			case ModuleFunction.SYSTEM_PART: {
+				type = ModuleType.SYSTEM_PART;
+				switch (moduleInfo.moduleIndex) {
+					case 1:
+						typeStr = 'systemPart';
+						break;
+					case 2:
+						typeStr = 'systemPart2';
+						break;
+					case 3:
+						typeStr = 'systemPart3';
+						break;
+					default:
+						throw new Error(`Unexpected index of a system part module: ${moduleInfo.moduleIndex}`);
+				}
+				break;
+			}
+			case ModuleFunction.USER_PART: {
+				type = ModuleType.USER_PART;
+				typeStr = 'userPart';
+				break;
+			}
+			case ModuleFunction.NCP_FIRMWARE: {
+				type = ModuleType.NCP_FIRMWARE;
+				typeStr = 'ncpFirmware';
+				break;
+			}
+			case ModuleFunction.RADIO_STACK: {
+				type = ModuleType.RADIO_STACK;
+				typeStr = 'radioStack';
+				break;
+			}
+			case ModuleFunction.MONO_FIRMWARE:
+			case ModuleFunction.RESOURCE:
+			case ModuleFunction.SETTINGS: {
+				throw new Error(`Unsupported module function: ${moduleInfo.moduleFunction}`);
+			}
+			default: {
+				throw new Error(`Unknown module function: ${moduleInfo.moduleFunction}`);
+			}
+		}
+		moduleInfo = platform.firmwareModules.find(m => m.type === typeStr);
+		if (!moduleInfo) {
+			throw new Error(`Cannot determine storage for module type: ${typeStr}`);
+		}
+		let storage; // Internal storage type
+		switch (moduleInfo.storage) {
+			case 'internalFlash':
+				storage = StorageType.INTERNAL_FLASH;
+				break;
+			case 'externalFlash':
+				storage = StorageType.EXTERNAL_FLASH;
+				break;
+			case 'externalMcu':
+				storage = StorageType.EXTERNAL_MCU;
+				break;
+			default:
+				throw new Error(`Unknown module storage: ${moduleInfo.storage}`);
+		}
+		return { type, storage };
 	}
 
 	async _listOlderReleaseVersions(version) {

--- a/lib/openocd.js
+++ b/lib/openocd.js
@@ -1,5 +1,4 @@
 const { Device, FlashInterface, StorageType } = require('./device');
-const { platformCommonsForMcu } = require('./platform');
 const { delay, formatCommand, isSpace, isPrintable, toUInt32Hex } = require('./util');
 
 const usb = require('usb');
@@ -50,8 +49,44 @@ const ADAPTER_INFO = [
 	}
 ];
 
+// Supported MCUs
+const MCU_INFO = [
+	{
+		baseMcu: 'stm32f2xx',
+		targetConfig: 'stm32f2x.cfg',
+		mcuManufacturer: 'STMicroelectronics', // JEDEC manufacturer string
+		deviceIdAddress: 0x1fff7a10, // UID
+		// By default, Device OS for Gen 2 platforms is built without support for JTAG/SWD debugging,
+		// so the target device needs to be reset when attaching to it with a debugger
+		assertSrstOnConnect: true,
+		// The bootloader's sector in flash may be locked
+		unlockFlash: true
+	},
+	{
+		baseMcu: 'nrf52840',
+		targetConfig: 'nrf52.cfg',
+		mcuManufacturer: 'Nordic VLSI ASA',
+		deviceIdAddress: 0x10000060, // FICR
+		deviceIdPrefix: 'e00fce68'
+	},
+	{
+		baseMcu: 'rtl872x',
+		targetConfig: 'rtl872x.tcl',
+		mcuManufacturer: 'Realtek',
+		deviceIdProcedure: 'rtl872x_read_efuse_mac; rtl872x_wdg_reset',
+		deviceIdPrefix: '0a10aced2021',
+		deviceIdRegex: new RegExp(`MAC:\\s([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2})`),
+		// FIXME: verification is disabled, it fails on some versions of OpenOCD
+		flashWriteProcedure: (binary, address) => {
+			return `rtl872x_flash_write_bin_ext ${binary} ${address} 1 1`;
+		},
+		resetRunProcedure: 'rtl872x_wdg_reset',
+	}
+];
+
 const ADAPTER_INFO_BY_USB_ID = ADAPTER_INFO.reduce((map, info) =>
 	map.set(makeUsbDeviceId(info.usbVendorId, info.usbProductId), info), new Map());
+const MCU_INFO_BY_NAME = MCU_INFO.reduce((map, info) => map.set(info.baseMcu, info), new Map());
 
 const DEFAULT_TELNET_PORT = 4444;
 
@@ -67,6 +102,14 @@ const MIN_DEVICE_RESET_INTERVAL = 5000;
 const DEVICE_ID_SIZE = 24; // Hex-encoded
 
 const ARM_MAX_DEBUG_PORTS = 5;
+
+function getMcuInfo(mcu) {
+	const info = MCU_INFO_BY_NAME.get(mcu);
+	if (!info) {
+		throw new Error(`Unknown MCU: ${mcu}`);
+	}
+	return info;
+}
 
 function makeUsbDeviceId(vendorId, productId) {
 	return [vendorId, productId].map(id => id.toString(16).padStart(4, '0')).join(':');
@@ -421,7 +464,7 @@ class OpenOcdDevice extends Device {
 					platform = await this._detectPlatform({ assertSrst: true });
 				}
 				this._log.verbose(`Target platform: ${platform.baseMcu}`);
-				this._target = platform.openOcd;
+				this._target = platform;
 			}
 			const cmds = [
 				`${this._info.serialParam} ${this._serial}`,
@@ -531,7 +574,7 @@ class OpenOcdDevice extends Device {
 		try {
 			const platformMcu = this._info.platformMcu;
 			if (platformMcu.length === 1) {
-				return platformCommonsForMcu(platformMcu[0]);
+				return getMcuInfo(platformMcu[0]);
 			}
 			const trans = this._info.transport;
 			if (trans !== 'swd') {
@@ -567,10 +610,9 @@ class OpenOcdDevice extends Device {
 				resp += r;
 			}
 			let platform = null;
-			for (const gen of platformMcu) {
-				// TODO: This will likely not work for future platforms
-				const p = platformCommonsForMcu(gen);
-				if (resp.includes(p.openOcd.mcuManufacturer)) {
+			for (const mcu of platformMcu) {
+				const p = getMcuInfo(mcu);
+				if (resp.includes(p.mcuManufacturer)) {
 					platform = p;
 					break;
 				}

--- a/lib/openocd.js
+++ b/lib/openocd.js
@@ -1,4 +1,5 @@
-const { Device, FlashInterface, StorageType } = require('./device');
+const { Device, FlashInterface } = require('./device');
+const { StorageType } = require('./platform');
 const { delay, formatCommand, isSpace, isPrintable, toUInt32Hex } = require('./util');
 
 const usb = require('usb');

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -98,7 +98,7 @@ class Platform {
 		if (!s) {
 			return null;
 		}
-		return s;
+		return s.alt;
 	}
 
 	get id() {

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -77,10 +77,10 @@ class Platform {
 			return null;
 		}
 		if (m.length === 1) {
+			m = m[0];
 			if (m.index !== undefined && m.index !== index) {
 				return null;
 			}
-			m = m[0];
 		} else {
 			m = m.find((m) => m.index === index);
 			if (!m) {

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -1,182 +1,11 @@
-const { StorageType } = require('./device');
+const deviceConstants = require('@particle/device-constants');
 
-const _ = require('lodash');
-
-const PLATFORM_COMMONS = [
-	{
-		baseMcu: 'stm32f2xx',
-		internalFlash: {
-			dfuAltSetting: 0
-		},
-		dct: {
-			dfuAltSetting: 1,
-			storage: StorageType.INTERNAL_FLASH,
-			address: 0x08004000,
-			size: 32768 // 2 pages
-		},
-		openOcd: {
-			targetConfig: 'stm32f2x.cfg',
-			mcuManufacturer: 'STMicroelectronics', // JEDEC manufacturer string
-			deviceIdAddress: 0x1fff7a10, // UID
-			// By default, Device OS for Gen 2 platforms is built without support for JTAG/SWD debugging,
-			// so the target device needs to be reset when attaching to it with a debugger
-			assertSrstOnConnect: true,
-			// The bootloader's sector in flash may be locked
-			unlockFlash: true
-		}
-	},
-	{
-		baseMcu: 'nrf52840',
-		hasRadioStack: true,
-		internalFlash: {
-			dfuAltSetting: 0
-		},
-		externalFlash: {
-			dfuAltSetting: 2
-		},
-		dct: {
-			dfuAltSetting: 1,
-			storage: StorageType.FILESYSTEM
-		},
-		filesystem: {
-			storage: StorageType.EXTERNAL_FLASH,
-			address: 0x80000000,
-			size: 2 * 1024 * 1024
-		},
-		openOcd: {
-			targetConfig: 'nrf52.cfg',
-			mcuManufacturer: 'Nordic VLSI ASA',
-			deviceIdAddress: 0x10000060, // FICR
-			deviceIdPrefix: 'e00fce68'
-		}
-	},
-	{
-		baseMcu: 'rtl872x',
-		internalFlash: {
-			dfuAltSetting: 0
-		},
-		externalFlash: {
-			dfuAltSetting: 2
-		},
-		dct: {
-			dfuAltSetting: 1,
-			storage: StorageType.FILESYSTEM
-		},
-		filesystem: {
-			storage: StorageType.EXTERNAL_FLASH,
-			address: 0x08600000,
-			size: 2 * 1024 * 1024
-		},
-		encryptedModules: [
-			{
-				// MBR is expected to be encrypted
-				index: 1,
-				type: 'bootloader'
-			}
-		],
-		openOcd: {
-			targetConfig: 'rtl872x.tcl',
-			mcuManufacturer: 'Realtek',
-			deviceIdProcedure: 'rtl872x_read_efuse_mac; rtl872x_wdg_reset',
-			deviceIdPrefix: '0a10aced2021',
-			deviceIdRegex: new RegExp(`MAC:\\s([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2}):([A-Fa-f0-9]{2})`),
-			// FIXME: verification is disabled, it fails on some versions of OpenOCD
-			flashWriteProcedure: (binary, address) => {
-				return `rtl872x_flash_write_bin_ext ${binary} ${address} 1 1`;
-			},
-			resetRunProcedure: 'rtl872x_wdg_reset',
-		}
-	},
-];
-
-const PLATFORM_COMMONS_BY_MCU = PLATFORM_COMMONS.reduce((map, p) => map.set(p.baseMcu, p), new Map());
-
-// Supported Device OS platforms
-const PLATFORMS = [
-	{
-		id: 6,
-		name: 'photon',
-		displayName: 'Photon',
-		baseMcu: 'stm32f2xx'
-	},
-	{
-		id: 8,
-		name: 'p1',
-		displayName: 'P1',
-		baseMcu: 'stm32f2xx'
-	},
-	{
-		id: 10,
-		name: 'electron',
-		displayName: 'Electron',
-		baseMcu: 'stm32f2xx'
-	},
-	{
-		id: 12,
-		name: 'argon',
-		displayName: 'Argon',
-		baseMcu: 'nrf52840',
-		hasNcpFirmware: true
-	},
-	{
-		id: 13,
-		name: 'boron',
-		displayName: 'Boron',
-		baseMcu: 'nrf52840'
-	},
-	{
-		id: 14,
-		name: 'xenon',
-		displayName: 'Xenon',
-		baseMcu: 'nrf52840'
-	},
-	{
-		id: 22,
-		name: 'asom',
-		displayName: 'A SoM',
-		baseMcu: 'nrf52840',
-		hasNcpFirmware: true
-	},
-	{
-		id: 23,
-		name: 'bsom',
-		displayName: 'B SoM',
-		baseMcu: 'nrf52840'
-	},
-	{
-		id: 25,
-		name: 'b5som',
-		displayName: 'B5 SoM',
-		baseMcu: 'nrf52840',
-		filesystem: {
-			size: 4 * 1024 * 1024
-		}
-	},
-	{
-		id: 26,
-		name: 'tracker',
-		displayName: 'Tracker',
-		baseMcu: 'nrf52840',
-		filesystem: {
-			size: 4 * 1024 * 1024
-		}
-	},
-	{
-		id: 32,
-		name: 'p2',
-		displayName: 'P2',
-		baseMcu: 'rtl872x',
-		filesystem: {
-			size: 8 * 1024 * 1024
-		}
-	}
-].map(p => _.merge({}, PLATFORM_COMMONS_BY_MCU.get(p.baseMcu), p));
-
-const PLATFORMS_BY_ID = PLATFORMS.reduce((map, p) => map.set(p.id, p), new Map());
-const PLATFORMS_BY_NAME = PLATFORMS.reduce((map, p) => map.set(p.name, p), new Map());
+const platforms = Object.values(deviceConstants).filter(p => p.generation >= 2);
+const platformsById = platforms.reduce((map, p) => map.set(p.id, p), new Map());
+const platformsByName = platforms.reduce((map, p) => map.set(p.name, p), new Map());
 
 function platformForId(id) {
-	const p = PLATFORMS_BY_ID.get(id);
+	const p = platformsById.get(id);
 	if (!p) {
 		throw new RangeError(`Unknown platform ID: ${id}`);
 	}
@@ -184,24 +13,14 @@ function platformForId(id) {
 }
 
 function platformForName(name) {
-	const p = PLATFORMS_BY_NAME.get(name);
+	const p = platformsByName.get(name);
 	if (!p) {
 		throw new RangeError(`Unknown platform name: ${name}`);
 	}
 	return p;
 }
 
-function platformCommonsForMcu(mcu) {
-	const p = PLATFORM_COMMONS_BY_MCU.get(mcu);
-	if (!p) {
-		throw new RangeError('Hello from 2020!');
-	}
-	return p;
-}
-
 module.exports = {
-	PLATFORMS,
 	platformForId,
-	platformForName,
-	platformCommonsForMcu
+	platformForName
 };

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -1,6 +1,132 @@
 const deviceConstants = require('@particle/device-constants');
 
-const platforms = Object.values(deviceConstants).filter(p => p.generation >= 2);
+const ModuleType = {
+	USER_PART: 'user_part',
+	SYSTEM_PART: 'system_part',
+	BOOTLOADER: 'bootloader',
+	RADIO_STACK: 'radio_stack',
+	NCP_FIRMWARE: 'ncp_firmware'
+};
+
+const StorageType = {
+	INTERNAL_FLASH: 'internal_flash',
+	EXTERNAL_FLASH: 'external_flash',
+	EXTERNAL_MCU: 'external_mcu'
+};
+
+function moduleTypeFromString(str) {
+	switch (str) {
+		case 'bootloader':
+			return ModuleType.BOOTLOADER;
+		case 'systemPart':
+			return ModuleType.SYSTEM_PART;
+		case 'userPart':
+			return ModuleType.USER_PART;
+		case 'radioStack':
+			return ModuleType.RADIO_STACK;
+		case 'ncpFirmware':
+			return ModuleType.NCP_FIRMWARE;
+		default:
+			throw new Error(`Unsupported module type: ${str}`);
+	}
+}
+
+function storageTypeFromString(str) {
+	switch (str) {
+		case 'internalFlash':
+			return StorageType.INTERNAL_FLASH;
+		case 'externalFlash':
+			return StorageType.EXTERNAL_FLASH;
+		case 'externalMcu':
+			return StorageType.EXTERNAL_MCU;
+		default:
+			throw new Error(`Unsupported storage type: ${str}`);
+	}
+}
+
+class Platform {
+	constructor(info) {
+		this._id = info.id;
+		this._name = info.name;
+		this._displayName = info.displayName;
+		this._baseMcu = info.baseMcu;
+		this._fwModules = [];
+		for (const moduleInfo of info.firmwareModules) {
+			const m = {
+				type: moduleTypeFromString(moduleInfo.type),
+				storage: storageTypeFromString(moduleInfo.storage),
+				encrypted: !!moduleInfo.encrypted
+			};
+			if (moduleInfo.index !== undefined) {
+				m.index = moduleInfo.index;
+			}
+			this._fwModules.push(m);
+		}
+		this._dfuStorage = [];
+		for (const storageInfo of info.dfu.storage) {
+			this._dfuStorage.push({
+				type: storageTypeFromString(storageInfo.type),
+				alt: storageInfo.alt
+			});
+		}
+	}
+
+	storageForFirmwareModule(type, index) {
+		let m = this._fwModules.filter((m) => m.type === type);
+		if (!m.length) {
+			return null;
+		}
+		if (m.length === 1) {
+			if (m.index !== undefined && m.index !== index) {
+				return null;
+			}
+			m = m[0];
+		} else {
+			m = m.find((m) => m.index === index);
+			if (!m) {
+				return null;
+			}
+		}
+		return {
+			type: m.storage,
+			encrypted: m.encrypted
+		};
+	}
+
+	dfuAltSettingForStorage(type) {
+		const s = this._dfuStorage.find((s) => s.type === type);
+		if (!s) {
+			return null;
+		}
+		return s;
+	}
+
+	get id() {
+		return this._id;
+	}
+
+	get name() {
+		return this._name;
+	}
+
+	get displayName() {
+		return this._displayName;
+	}
+
+	get baseMcu() {
+		return this._baseMcu;
+	}
+
+	get hasRadioStack() {
+		return this._fwModules.some((m) => m.type === ModuleType.RADIO_STACK);
+	}
+
+	get hasNcpFirmware() {
+		return this._fwModules.some((m) => m.type === ModuleType.NCP_FIRMWARE);
+	}
+}
+
+const platforms = Object.values(deviceConstants).filter(p => p.generation >= 2).map(p => new Platform(p));
 const platformsById = platforms.reduce((map, p) => map.set(p.id, p), new Map());
 const platformsByName = platforms.reduce((map, p) => map.set(p.name, p), new Map());
 
@@ -21,6 +147,8 @@ function platformForName(name) {
 }
 
 module.exports = {
+	ModuleType,
+	StorageType,
 	platformForId,
 	platformForName
 };

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -27,7 +27,7 @@ function moduleTypeFromString(str) {
 		case 'ncpFirmware':
 			return ModuleType.NCP_FIRMWARE;
 		default:
-			throw new Error(`Unsupported module type: ${str}`);
+			throw new Error(`Unknown module type: ${str}`);
 	}
 }
 
@@ -40,7 +40,7 @@ function storageTypeFromString(str) {
 		case 'externalMcu':
 			return StorageType.EXTERNAL_MCU;
 		default:
-			throw new Error(`Unsupported storage type: ${str}`);
+			throw new Error(`Unknown storage type: ${str}`);
 	}
 }
 
@@ -149,6 +149,7 @@ function platformForName(name) {
 module.exports = {
 	ModuleType,
 	StorageType,
+	Platform,
 	platformForId,
 	platformForName
 };

--- a/lib/platform.test.js
+++ b/lib/platform.test.js
@@ -95,6 +95,13 @@ describe('Platform', () => {
 				...platformInfo,
 				firmwareModules: [
 					{ type: 'systemPart', index: 1, storage: 'internalFlash' },
+				]
+			});
+			expect(p.storageForFirmwareModule(ModuleType.SYSTEM_PART, 2)).to.be.null;
+			p = new Platform({
+				...platformInfo,
+				firmwareModules: [
+					{ type: 'systemPart', index: 1, storage: 'internalFlash' },
 					{ type: 'systemPart', index: 2, storage: 'internalFlash' }
 				]
 			});

--- a/lib/platform.test.js
+++ b/lib/platform.test.js
@@ -1,0 +1,166 @@
+const { Platform, ModuleType, StorageType } = require('./platform');
+
+const { expect } = require('chai');
+
+describe('Platform', () => {
+	const platformInfo = {
+		id: 123,
+		name: 'abc',
+		displayName: 'Abc',
+		baseMcu: 'xyz',
+		firmwareModules: [
+			{ type: 'bootloader', storage: 'internalFlash', encrypted: true },
+			{ type: 'systemPart', storage: 'internalFlash' },
+			{ type: 'userPart', storage: 'internalFlash' },
+			{ type: 'radioStack', storage: 'externalFlash' },
+			{ type: 'ncpFirmware', storage: 'externalMcu' }
+		],
+		dfu: {
+			storage: [
+				{ type: 'internalFlash', alt: 111 },
+				{ type: 'externalFlash', alt: 222 },
+				{ type: 'externalMcu', alt: 333 }
+			]
+		}
+	};
+
+	describe('constructor', () => {
+		it('constructs a platform object from device-constants definitions', () => {
+			const p = new Platform(platformInfo);
+			expect(p.id).to.equal(123);
+			expect(p.name).to.equal('abc');
+			expect(p.displayName).to.equal('Abc');
+			expect(p.baseMcu).to.equal('xyz');
+			expect(p.hasRadioStack).to.be.true;
+			expect(p.hasNcpFirmware).to.be.true;
+			expect(p.storageForFirmwareModule(ModuleType.BOOTLOADER)).to.deep.equal({ type: StorageType.INTERNAL_FLASH, encrypted: true });
+			expect(p.storageForFirmwareModule(ModuleType.SYSTEM_PART)).to.deep.equal({ type: StorageType.INTERNAL_FLASH, encrypted: false });
+			expect(p.storageForFirmwareModule(ModuleType.USER_PART)).to.deep.equal({ type: StorageType.INTERNAL_FLASH, encrypted: false });
+			expect(p.storageForFirmwareModule(ModuleType.RADIO_STACK)).to.deep.equal({ type: StorageType.EXTERNAL_FLASH, encrypted: false });
+			expect(p.storageForFirmwareModule(ModuleType.NCP_FIRMWARE)).to.deep.equal({ type: StorageType.EXTERNAL_MCU, encrypted: false });
+			expect(p.dfuAltSettingForStorage(StorageType.INTERNAL_FLASH)).to.equal(111);
+			expect(p.dfuAltSettingForStorage(StorageType.EXTERNAL_FLASH)).to.equal(222);
+			expect(p.dfuAltSettingForStorage(StorageType.EXTERNAL_MCU)).to.equal(333);
+		});
+
+		it('fails if the platform definitions contain an unknown module type', () => {
+			expect(() => new Platform({
+				...platformInfo,
+				firmwareModules: [
+					{ type: 'newModuleType', storage: 'internalFlash' }
+				]
+			})).to.throw('Unknown module type: newModuleType');
+		});
+
+		it('fails if the platform definitions contain an unknown storage type', () => {
+			expect(() => new Platform({
+				...platformInfo,
+				firmwareModules: [
+					{ type: 'systemPart', storage: 'newStorageType' }
+				]
+			})).to.throw('Unknown storage type: newStorageType');
+		});
+	});
+
+	describe('storageForFirmwareModule', () => {
+		it('returns the storage info for a firmware module type and index', () => {
+			let p = new Platform({
+				...platformInfo,
+				firmwareModules: [
+					{ type: 'systemPart', storage: 'internalFlash' }
+				]
+			});
+			expect(p.storageForFirmwareModule(ModuleType.SYSTEM_PART)).to.deep.equal({ type: StorageType.INTERNAL_FLASH, encrypted: false });
+			expect(p.storageForFirmwareModule(ModuleType.SYSTEM_PART, 2)).to.deep.equal({ type: StorageType.INTERNAL_FLASH, encrypted: false });
+			p = new Platform({
+				...platformInfo,
+				firmwareModules: [
+					{ type: 'systemPart', index: 1, storage: 'internalFlash' },
+					{ type: 'systemPart', index: 2, storage: 'externalFlash', encrypted: true }
+				]
+			});
+			expect(p.storageForFirmwareModule(ModuleType.SYSTEM_PART, 1)).to.deep.equal({ type: StorageType.INTERNAL_FLASH, encrypted: false });
+			expect(p.storageForFirmwareModule(ModuleType.SYSTEM_PART, 2)).to.deep.equal({ type: StorageType.EXTERNAL_FLASH, encrypted: true });
+		});
+
+		it('returns null if the storage info is not found', () => {
+			let p = new Platform({
+				...platformInfo,
+				firmwareModules: [
+					{ type: 'systemPart', storage: 'internalFlash' }
+				]
+			});
+			expect(p.storageForFirmwareModule(ModuleType.USER_PART)).to.be.null;
+			p = new Platform({
+				...platformInfo,
+				firmwareModules: [
+					{ type: 'systemPart', index: 1, storage: 'internalFlash' },
+					{ type: 'systemPart', index: 2, storage: 'internalFlash' }
+				]
+			});
+			expect(p.storageForFirmwareModule(ModuleType.SYSTEM_PART, 3)).to.be.null;
+		});
+	});
+
+	describe('dfuAltSettingForStorage', () => {
+		it('returns the alt setting for a storage type', () => {
+			const p = new Platform({
+				...platformInfo,
+				dfu: {
+					storage: [
+						{ type: 'internalFlash', alt: 1 },
+						{ type: 'externalFlash', alt: 2 }
+					]
+				}
+			});
+			expect(p.dfuAltSettingForStorage(StorageType.INTERNAL_FLASH)).to.equal(1);
+			expect(p.dfuAltSettingForStorage(StorageType.EXTERNAL_FLASH)).to.equal(2);
+		});
+
+		it('returns null if the alt setting is not found', () => {
+			const p = new Platform({
+				...platformInfo,
+				dfu: {
+					storage: [
+						{ type: 'internalFlash', alt: 1 }
+					]
+				}
+			});
+			expect(p.dfuAltSettingForStorage(StorageType.EXTERNAL_FLASH)).to.be.null;
+		});
+	});
+
+	describe('hasRadioStack', () => {
+		it('returns true if the platform has a radio stack module, or false otherwise', () => {
+			let p = new Platform({
+				...platformInfo,
+				firmwareModules: [
+					{ type: 'radioStack', storage: 'internalFlash' }
+				]
+			});
+			expect(p.hasRadioStack).to.be.true;
+			p = new Platform({
+				...platformInfo,
+				firmwareModules: []
+			});
+			expect(p.hasRadioStack).to.be.false;
+		});
+	});
+
+	describe('hasNcpFirmware', () => {
+		it('returns true if the platform has an NCP firmware module, or false otherwise', () => {
+			let p = new Platform({
+				...platformInfo,
+				firmwareModules: [
+					{ type: 'ncpFirmware', storage: 'externalMcu' }
+				]
+			});
+			expect(p.hasNcpFirmware).to.be.true;
+			p = new Platform({
+				...platformInfo,
+				firmwareModules: []
+			});
+			expect(p.hasNcpFirmware).to.be.false;
+		});
+	});
+});

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -588,9 +588,9 @@
 			}
 		},
 		"@particle/device-constants": {
-			"version": "1.8.0-rc.0",
-			"resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-1.8.0-rc.0.tgz",
-			"integrity": "sha512-Ts1wJHs11df0PaELL1oKKofH1Xl7kwhsNZjSpCsNlaSXPWGZ2PCLtRqOder/mn5LwNNIRj6hhhHGNGnCh5YneQ=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-2.0.0.tgz",
+			"integrity": "sha512-GGcebFK/A7trvUnXhyq3sWq6XvX/GSO6AJsjFFiDm9Qs+UtgmlVuPdLW6xaZR7gZgMT+siBhnxvZg+iDTEfTsg=="
 		},
 		"@protobufjs/aspromise": {
 			"version": "1.1.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -588,9 +588,9 @@
 			}
 		},
 		"@particle/device-constants": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-1.3.0.tgz",
-			"integrity": "sha512-OI7K5yEsN8R/ommsM0IiFfQSEN0NhPFelQGLKIQ+yNXUVvEsZOW18QdZirLreKIheIrqsZOhuqppDp0orykL6g=="
+			"version": "1.8.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-1.8.0-rc.0.tgz",
+			"integrity": "sha512-Ts1wJHs11df0PaELL1oKKofH1Xl7kwhsNZjSpCsNlaSXPWGZ2PCLtRqOder/mn5LwNNIRj6hhhHGNGnCh5YneQ=="
 		},
 		"@protobufjs/aspromise": {
 			"version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	},
 	"dependencies": {
 		"@octokit/rest": "^18.9.1",
-		"@particle/device-constants": "^1.8.0-rc.0",
+		"@particle/device-constants": "^2.0.0",
 		"binary-version-reader": "^1.1.2",
 		"chalk": "^3.0.0",
 		"decompress": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	},
 	"dependencies": {
 		"@octokit/rest": "^18.9.1",
-		"@particle/device-constants": "^1.3.0",
+		"@particle/device-constants": "^1.8.0-rc.0",
 		"binary-version-reader": "^1.1.2",
 		"chalk": "^3.0.0",
 		"decompress": "^4.2.1",


### PR DESCRIPTION
This PR introduces the following changes:

- Use device-constants instead of own platform definitions.
- Remove the unused factory reset feature in order to avoid hardcoding DCT and filesystem addresses in device-constants.

#### Steps to test

Flashing via DFU and OpenOCD should work as expected.

#### References

- [sc-98439](https://app.shortcut.com/particle/story/98439/move-definitions-specific-to-device-os-flash-util-to-device-constants-npm-module)
- [device-constants#20](https://github.com/particle-iot-inc/device-constants/pull/20)
