### PR TITLE
Use forward path slashes when providing paths to OpenOCD on Windows

### DIFF
--- a/lib/openocd.js
+++ b/lib/openocd.js
@@ -9,6 +9,9 @@ const which = require('which');
 const EventEmitter = require('events');
 const { spawn } = require('child_process');
 
+const path = require('path');
+const os = require('os');
+
 const AdapterType = {
 	DAPLINK: 'daplink',
 	STLINK_V2: 'stlink_v2',
@@ -535,6 +538,11 @@ class OpenOcdDevice extends Device {
 		if (!this.canWriteToFlash(storage)) {
 			throw new Error('Unsupported storage');
 		}
+		// OpenOCD on Windows is bad with paths with backslashes, convert to forward slashes
+		if (os.platform() === 'win32') {
+			file = file.split(path.sep).join(path.posix.sep);
+		}
+
 		const addrStr = toUInt32Hex(address);
 		if (!this._target.flashWriteProcedure) {
 			if (this._target.unlockFlash) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
 	"name": "@particle/device-os-flash-util",
-	"version": "0.10.0",
+	"version": "0.10.1-rc.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@particle/device-os-flash-util",
-	"version": "0.10.0",
+	"version": "0.10.1-rc.0",
 	"description": "Device OS Flashing Utility",
 	"license": "Apache-2.0",
 	"main": "lib/index.js",


### PR DESCRIPTION
OpenOCD is bad with Windows paths in TCL scripts (which are used for example for P2 flashing) that contain backslashes and causes failures:

```
C:/Users/blah/Downloads/openocd/openocd/bin/..//scripts/target/rtl872x.tcl:265: Error: could not read "C:UsersblahAppDataLocalTempdevice-os-flash-18276k2sKUgNrgSPHdevice_1mbr-encrypted.module-no-header.bin": No such file or directory
```