### PR TITLE
[flasher] flash in dependency order if possible

### DIFF
--- a/lib/dependency.js
+++ b/lib/dependency.js
@@ -1,0 +1,68 @@
+class DependencyWalker {
+	constructor({ modules, log }) {
+		this._log = log;
+		this._modules = modules;
+		this._adjacencyList = new Map();
+	}
+
+	sortByDependencies(modules) {
+		if (modules) {
+			this._modules = modules;
+		}
+
+		this._fillAdjacencyList();
+
+		// This is pretty naive but works fine for our purposes
+		const ordered = [];
+		const visited = new Set();
+		for (const [m, deps] of this._adjacencyList.entries()) {
+			if (m in visited) {
+				continue;
+			}
+			const chain = [];
+			visited.add(m);
+			chain.push(m);
+			for (const d of deps) {
+				if (d in visited) {
+					continue;
+				}
+				visited.add(d);
+				chain.push(d);
+			}
+			const last = chain[chain.length - 1];
+			// Place into the appropriate location in the list
+			ordered.splice(ordered.indexOf(last), 0, ...chain);
+		}
+		// Remove any duplicates
+		return new Set(ordered);
+	}
+
+	_addEdgesByDependencies(module) {
+		// Fills the adjacency list in the reverse order of the dependencies
+		// e.g. system-part1 depends on bootloader: the list will contain bootloader -> system-part1 edge
+		for (const dep of module.dependencies) {
+			for (const m of this._modules) {
+				if (dep.func === m.func && dep.index === m.index) {
+					// Version is ignored as we don't really known what's on device
+					const moduleDependencies = this._adjacencyList.get(m);
+					moduleDependencies.add(module);
+				}
+			}
+		}
+	}
+
+	_fillAdjacencyList() {
+		this._adjacencyList = new Map();
+		for (const m of this._modules) {
+			this._adjacencyList.set(m, new Set());
+		}
+		for (const m of this._modules) {
+			this._addEdgesByDependencies(m);
+		}
+	}
+
+}
+
+module.exports = {
+	DependencyWalker
+};

--- a/lib/flasher.js
+++ b/lib/flasher.js
@@ -6,6 +6,8 @@ const mkdirp = require('mkdirp');
 const fs = require('fs');
 const path = require('path');
 
+const { DependencyWalker } = require('./dependency');
+
 // This timeout should be long enough to allow the bootloader apply an update
 const REOPEN_TIMEOUT = 60000;
 // When reopening a device that was about to reset, give it some time to boot into the firmware
@@ -29,9 +31,17 @@ class Flasher {
 			this._log.warn('Module list is empty');
 			return;
 		}
+
+		const depWalker = new DependencyWalker({ log: this._log });
+		modules = depWalker.sortByDependencies(modules);
+
 		const flashModules = []; // Modules that can be flashed directly
 		const otaModules = []; // Modules that can only be flashed OTA
 		for (const m of modules) {
+			if (m.needsToBeEncrypted && !m.encrypted) {
+				this._log.warn(`Skipping ${path.basename(m.file)}. It's required to be encrypted`);
+				continue;
+			}
 			if (this._dev.canFlashModule(m) && this._dev.canWriteToFlash(m.storage)) {
 				flashModules.push(m);
 			} else {
@@ -72,11 +82,6 @@ class Flasher {
 						await this._dev.prepareToFlash();
 					}
 					const m = modules[0];
-					if (m.needsToBeEncrypted && !m.encrypted) {
-						this._log.warn(`Skipping ${path.basename(m.file)}. It's required to be encrypted`);
-						modules.shift();
-						continue;
-					}
 					let file = m.file;
 					this._log.verbose('Flashing', path.basename(file));
 					if (m.dropHeader) {

--- a/lib/module.js
+++ b/lib/module.js
@@ -386,6 +386,21 @@ class ModuleCache {
 		const startAddr = Number.parseInt(info.moduleStartAddy, 16);
 		const endAddr = Number.parseInt(info.moduleEndAddy, 16);
 		const fileSize = fs.statSync(file).size;
+		const dependencies = [];
+		if (info.depModuleFunction !== ModuleFunction.NONE) {
+			dependencies.push({
+				func: info.depModuleFunction,
+				index: info.depModuleIndex,
+				version: info.depModuleVersion
+			});
+		}
+		if (info.dep2ModuleFunction !== ModuleFunction.NONE) {
+			dependencies.push({
+				func: info.dep2ModuleFunction,
+				index: info.dep2ModuleIndex,
+				version: info.dep2ModuleVersion
+			});
+		}
 		const m = {
 			platformId: platform.id,
 			type,
@@ -400,7 +415,10 @@ class ModuleCache {
 			needsToBeEncrypted: storageInfo.encrypted,
 			crcValid,
 			fileSize,
-			file
+			file,
+			// Used for figuring out optimal order based on dependencies
+			func: info.moduleFunction,
+			dependencies: dependencies
 		};
 		if (info.moduleFlags & ModuleInfo.Flags.DROP_MODULE_INFO) {
 			m.dropHeader = true;


### PR DESCRIPTION
A naive ordering based on dependencies when flashing over DFU/control requests. This resolves the issue with P2 prebootloader-part1 getting updated after bootloader (which fails).

Order after the fix:
```
[Device 1] Skipping p2-prebootloader-mbr@5.0.0-alpha.2.bin. It's required to be encrypted
[Device 1] Preparing device for flashing
[Device 1] Entering DFU mode
[Device 1] Flashing p2-system-part1@5.0.0-alpha.2.bin
[Device 1] $ dfu-util -d 0x2b04:0xd020 -p 3-5.1 -a 0 -s 0x08060000 -D /home/avtolstoy/.particle/device-os-flash/binaries/5.0.0-alpha.2/p2/p2-system-part1@5.0.0-alpha.2.bin
[Device 1] Flashed in 20.8s
[Device 1] Flashing p2-tinker@5.0.0-alpha.2.bin
[Device 1] $ dfu-util -d 0x2b04:0xd020 -p 3-5.1 -a 0 -s 0x085f4000 -D /home/avtolstoy/.particle/device-os-flash/binaries/5.0.0-alpha.2/p2/p2-tinker@5.0.0-alpha.2.bin
[Device 1] Flashed in 0.9s
[Device 1] Resetting device
[Device 1] Using control requests to flash remaining modules
[Device 1] Preparing device for flashing
[Device 1] Entering listening mode
[Device 1] Invalid state
[Device 1] Flashing p2-prebootloader-part1@5.0.0-alpha.2.bin
[Device 1] Flashed in 2.2s
[Device 1] Preparing device for flashing
[Device 1] Entering listening mode
[Device 1] Invalid state
[Device 1] Flashing p2-bootloader@5.0.0-alpha.2.bin
[Device 1] Flashed in 5.9s
[Device 1] Flashed successfully
Done
```

Before:
```
[Device 1] Preparing device for flashing
[Device 1] Flashing p2-system-part1@5.0.0-alpha.2.bin
[Device 1] Flashing p2-tinker@5.0.0-alpha.2.bin
[Device 1] Resetting device
[Device 1] Using control requests to flash remaining modules
[Device 1] Preparing device for flashing
[Device 1] Flashing p2-bootloader@5.0.0-alpha.2.bin
[Device 1] Request error
[Device 1] Retrying
[Device 1] Preparing device for flashing
[Device 1] Invalid state
[Device 1] Flashing p2-bootloader@5.0.0-alpha.2.bin
[Device 1] Request error
[Device 1] Retrying
[Device 1] Preparing device for flashing
[Device 1] Invalid state
[Device 1] Flashing p2-bootloader@5.0.0-alpha.2.bin
[Device 1] Request error
Error: Request error
```

Also fixes the check for encrypted modules to happen earlier (it wasn't working for DFU/USB flashing, only OpenOCD).