### PR TITLE
Bump constants dependency for trackerm flashing fix

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -588,9 +588,9 @@
 			}
 		},
 		"@particle/device-constants": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-2.0.0.tgz",
-			"integrity": "sha512-GGcebFK/A7trvUnXhyq3sWq6XvX/GSO6AJsjFFiDm9Qs+UtgmlVuPdLW6xaZR7gZgMT+siBhnxvZg+iDTEfTsg=="
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.0.1.tgz",
+			"integrity": "sha512-xskCcfBu+vh5eTebGE9LEejaKkdDueyea/nfFPCGLL7FJG51dDPZ1DfPZsueQuok4ok/V52KhZiOWH2oxkwq2Q=="
 		},
 		"@protobufjs/aspromise": {
 			"version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	},
 	"dependencies": {
 		"@octokit/rest": "^18.9.1",
-		"@particle/device-constants": "^2.0.0",
+		"@particle/device-constants": "^3.0.1",
 		"binary-version-reader": "^1.1.2",
 		"chalk": "^3.0.0",
 		"decompress": "^4.2.1",


### PR DESCRIPTION
Update `device-constants` dependency to version that has the correct trackerm bootloader modules defined. This should allow device-os-flash to work with trackerm correctly (ie flashing prebootloader-part1 and not prebootloader-mbr)